### PR TITLE
Indexer: Account for race conditions

### DIFF
--- a/.github/workflows/publish-sdk.yml
+++ b/.github/workflows/publish-sdk.yml
@@ -32,12 +32,12 @@ jobs:
               run: pnpm install
 
             - name: Build SDK
-              run: pnpm --filter="@hyperbridge/sdk" build
+              run: pnpm --filter="hyperbridge-sdk" build
 
             - name: Publish to npm
               run: |
                   echo "//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}" > ~/.npmrc
-                  pnpm --filter="@hyperbridge/sdk" publish --no-git-checks
+                  pnpm --filter="hyperbridge-sdk" publish --no-git-checks
               env:
                   NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 

--- a/.github/workflows/test-sdk.yml
+++ b/.github/workflows/test-sdk.yml
@@ -111,7 +111,7 @@ jobs:
                   sleep 10  # Give it a few more seconds to fully initialize
 
             - name: Run SDK tests
-              run: pnpm --filter="@hyperbridge/sdk" test
+              run: pnpm --filter="hyperbridge-sdk" test
 
             - name: Clean up
               if: always()

--- a/.github/workflows/test-sdk.yml
+++ b/.github/workflows/test-sdk.yml
@@ -93,13 +93,13 @@ jobs:
 
             - name: Wait for GraphQL server to be available
               run: |
-                  echo "Waiting for GraphQL server to be available on port 3000..."
+                  echo "Waiting for GraphQL server to be available on port 3100..."
                   timeout=300  # 5 minutes timeout
                   elapsed=0
                   interval=5
-                  while ! nc -z localhost 3000; do
+                  while ! nc -z localhost 3100; do
                     if [ "$elapsed" -ge "$timeout" ]; then
-                      echo "Timed out waiting for GraphQL server on port 3000"
+                      echo "Timed out waiting for GraphQL server on port 3100"
                       cat packages/indexer/indexer_output.log
                       exit 1
                     fi

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
 		"packages/*"
 	],
 	"scripts": {
-		"build": "pnpm --filter=\"@hyperbridge/subql-indexer\" build && pnpm --filter=\"@hyperbridge/sdk\" build",
+		"build": "pnpm --filter=\"@hyperbridge/subql-indexer\" build && pnpm --filter=\"hyperbridge-sdk\" build",
 		"test": "pnpm --filter=\"*\" test",
 		"lint": "pnpm --filter=\"*\" lint",
 		"format": "pnpm --filter=\"*\" format",

--- a/packages/indexer/docker/docker-compose.local.yml
+++ b/packages/indexer/docker/docker-compose.local.yml
@@ -2,11 +2,12 @@ services:
     subquery-node-hyperbridge-gargantua-local:
         image: subquerynetwork/subql-node-substrate:v5.9.1
         restart: unless-stopped
+        network_mode: host
         environment:
             DB_USER: ${DB_USER}
             DB_PASS: ${DB_PASS}
             DB_DATABASE: ${DB_DATABASE}
-            DB_HOST: ${DB_HOST}
+            DB_HOST: 0.0.0.0
             DB_PORT: ${DB_PORT}
 
         depends_on:
@@ -112,7 +113,7 @@ services:
         image: subquerynetwork/subql-query:v2.21.0
         restart: always
         ports:
-            - 3000:3000
+            - 3100:3000
         environment:
             DB_USER: ${DB_USER}
             DB_PASS: ${DB_PASS}

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -5,11 +5,11 @@ A JavaScript/TypeScript SDK for interacting with the Hyperbridge indexer and mon
 ## Installation
 
 ```bash
-npm install @hyperbridge/sdk
+npm install hyperbridge-sdk
 # or
-yarn add @hyperbridge/sdk
+yarn add hyperbridge-sdk
 # or
-pnpm add @hyperbridge/sdk
+pnpm add hyperbridge-sdk
 ```
 
 ## Usage
@@ -17,7 +17,7 @@ pnpm add @hyperbridge/sdk
 ### Initialize Client
 
 ```ts
-import { IndexerClient } from "@hyperbridge/sdk"
+import { IndexerClient } from "hyperbridge-sdk"
 
 const indexer = new IndexerClient({
 	source: {
@@ -45,7 +45,7 @@ const indexer = new IndexerClient({
 ### Monitor Post Request Status
 
 ```ts
-import { postRequestCommitment } from "@hyperbridge/sdk"
+import { postRequestCommitment } from "hyperbridge-sdk"
 
 // Get status stream for a commitment
 const commitment = postRequestCommitment(request)
@@ -90,7 +90,7 @@ console.log(request?.statuses)
 ### Chain Utilities
 
 ```ts
-import { EvmChain, SubstrateChain } from "@hyperbridge/sdk"
+import { EvmChain, SubstrateChain } from "hyperbridge-sdk"
 
 // Interact with EVM chains
 const evmChain = new EvmChain({

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,5 +1,5 @@
 {
-	"name": "@hyperbridge/sdk",
+	"name": "hyperbridge-sdk",
 	"version": "1.0.0",
 	"description": "The hyperclient SDK provides utilities for querying proofs and statuses for cross-chain requests from HyperBridge.",
 	"main": "dist/index.js",

--- a/packages/sdk/src/chains/substrate.ts
+++ b/packages/sdk/src/chains/substrate.ts
@@ -8,6 +8,7 @@ import { u8, Vector } from "scale-ts"
 import { BasicProof, isEvmChain, isSubstrateChain, IStateMachine, Message, SubstrateStateProof } from "@/utils"
 import { IChain, IIsmpMessage } from "@/chain"
 import { HexString, IPostRequest } from "@/types"
+import { keccakAsU8a } from "@polkadot/util-crypto"
 
 export interface SubstrateChainParams {
 	/*
@@ -33,8 +34,22 @@ export class SubstrateChain implements IChain {
 	 */
 	public async connect() {
 		const wsProvider = new WsProvider(this.params.ws)
+		const typesBundle =
+			this.params.hasher === "Keccak"
+				? {
+						spec: {
+							nexus: {
+								hasher: keccakAsU8a,
+							},
+							gargantua: {
+								hasher: keccakAsU8a,
+							},
+						},
+					}
+				: {}
 		this.api = await ApiPromise.create({
 			provider: wsProvider,
+			typesBundle,
 		})
 	}
 

--- a/packages/sdk/src/client.ts
+++ b/packages/sdk/src/client.ts
@@ -699,8 +699,6 @@ export class IndexerClient {
 		if (!request) throw new Error(`Request not found`)
 
 		const destChain = await getChain(self.config.dest)
-		const destTimestamp = await destChain.timestamp()
-		if (request.timeoutTimestamp > destTimestamp) throw new Error(`Request not timed out`)
 
 		// if the destination is hyperbridge, then just wait for hyperbridge finality
 		let status =

--- a/packages/sdk/src/tests/hyperbridgeRequests.test.ts
+++ b/packages/sdk/src/tests/hyperbridgeRequests.test.ts
@@ -50,7 +50,7 @@ describe("Hyperbridge Requests", () => {
 				stateMachineId: "KUSAMA-4009",
 				wsUrl: process.env.HYPERBRIDGE_GARGANTUA!,
 			},
-			url: "http://localhost:3000",
+			url: "http://localhost:3100",
 			pollInterval: 1_000, // every second
 		})
 	})
@@ -302,7 +302,7 @@ describe("Hyperbridge Requests", () => {
 				stateMachineId: "KUSAMA-4009",
 				wsUrl: process.env.HYPERBRIDGE_GARGANTUA!,
 			},
-			url: "http://localhost:3000",
+			url: "http://localhost:3100",
 			pollInterval: 1_000, // every second
 		})
 

--- a/packages/sdk/src/tests/hyperbridgeRequests.test.ts
+++ b/packages/sdk/src/tests/hyperbridgeRequests.test.ts
@@ -152,7 +152,7 @@ describe("Hyperbridge Requests", () => {
 			destination: 97,
 			recipient: "0x742d35Cc6634C0532925a3b844Bc454e4438f44e" as HexString,
 			amount: BigInt(1),
-			timeout: BigInt(10),
+			timeout: BigInt(1),
 			paraId: 4009,
 		}
 
@@ -320,7 +320,7 @@ describe("Hyperbridge Requests", () => {
 				nativeCost: BigInt(0),
 				redeem: false,
 				relayerFee: parseUnits("0", 18),
-				timeout: BigInt(20),
+				timeout: BigInt(1),
 				to: "0xe95696ab27a7ffc9c1a9969003787c8e3c7dcd87aa36238082eb22e67ec0e4ce",
 			},
 		])

--- a/packages/sdk/src/tests/postRequest.test.ts
+++ b/packages/sdk/src/tests/postRequest.test.ts
@@ -21,7 +21,7 @@ import ERC6160 from "@/abis/erc6160"
 import PING_MODULE from "@/abis/pingModule"
 import EVM_HOST from "@/abis/evmHost"
 import HANDLER from "@/abis/handler"
-import { DEFAULT_ADDRESS, EvmChain, SubstrateChain } from "@/chain"
+import { EvmChain, SubstrateChain } from "@/chain"
 
 describe("PostRequest", () => {
 	let indexer: IndexerClient
@@ -46,6 +46,7 @@ describe("PostRequest", () => {
 				stateMachineId: "KUSAMA-4009",
 				wsUrl: process.env.HYPERBRIDGE_GARGANTUA!,
 			},
+			url: "http://0.0.0.0:3100",
 			pollInterval: 1_000, // every second
 		})
 	})
@@ -196,6 +197,9 @@ describe("PostRequest", () => {
 			},
 		])
 
+		// wait for tx receipt to become available
+		await new Promise((resolve) => setTimeout(resolve, 5000))
+
 		const receipt = await bscTestnetClient.waitForTransactionReceipt({
 			hash,
 			confirmations: 1,
@@ -214,6 +218,8 @@ describe("PostRequest", () => {
 		const request = event.args
 
 		console.log("PostRequestEvent", { request })
+
+		console.log("Request Commitment: ", postRequestCommitment(request))
 
 		const commitment = postRequestCommitment(request)
 		const statusStream = indexer.postRequestStatusStream(commitment)

--- a/packages/sdk/src/tests/postRequest.test.ts
+++ b/packages/sdk/src/tests/postRequest.test.ts
@@ -183,7 +183,7 @@ describe("PostRequest", () => {
 		expect(req?.statuses.length).toBe(5)
 	}, 600_000)
 
-	test.fails("should stream and query the timeout status", async () => {
+	it("should stream and query the timeout status", async () => {
 		const { bscTestnetClient, bscHandler, bscPing, gnosisChiadoHost } = await setUp()
 		console.log("\n\nSending Post Request\n\n")
 

--- a/packages/sdk/src/utils/xcmGateway.ts
+++ b/packages/sdk/src/utils/xcmGateway.ts
@@ -288,7 +288,7 @@ async function watchForRequestCommitment(
 
 			last_block = finalized + 1
 
-			if (blockCount >= 30) {
+			if (blockCount >= 50) {
 				unsubscribeHyperbridgeEvents?.()
 				reject(new Error("No commitment received"))
 			}

--- a/packages/sdk/src/utils/xcmGateway.ts
+++ b/packages/sdk/src/utils/xcmGateway.ts
@@ -330,9 +330,7 @@ export function extractCommitmentHashFromEvent({
 		to.toString().toLowerCase() === params.recipient.toLowerCase() &&
 		dest.toString().includes(params.destination?.toString())
 
-	if (!isExpectedEvent) {
-		throw new Error("Error extracting commitment. Data mismatch")
+	if (isExpectedEvent) {
+		return commitment.toString() as HexString
 	}
-
-	return commitment.toString() as HexString
 }

--- a/packages/sdk/vitest.config.ts
+++ b/packages/sdk/vitest.config.ts
@@ -1,7 +1,5 @@
 import { defineConfig } from "vitest/config"
 import tsconfigPaths from "vite-tsconfig-paths"
-import { loadEnv } from "vite"
-import path from "node:path"
 export default defineConfig({
 	plugins: [tsconfigPaths()],
 	test: {


### PR DESCRIPTION
The indexers for different networks might see a new request status before the the actual request is indexed. This update allows for the request to be created when these statuses are observed and the actual request filled in later.