### PR TITLE
Exposed queryPostRequest, queryGetRquest and createQueryClient

### DIFF
--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -17,7 +17,7 @@ pnpm add hyperbridge-sdk
 ### Initialize Client
 
 ```ts
-import { IndexerClient } from "hyperbridge-sdk"
+import { IndexerClient, createQueryClient } from "hyperbridge-sdk"
 
 const queryClient = createQueryClient({
 	url: "http://localhost:3000", // URL of the Hyperbridge indexer API
@@ -91,10 +91,10 @@ const request = await indexer.queryRequestWithStatus(commitment)
 console.log(request?.statuses)
 ```
 
-Alternatively. You can use the `queryRequest` utility
+Alternatively. You can use the `queryPostRequest` utility
 
 ```ts
-import { createQueryClient, queryRequest } from "hyperbridge-sdk"
+import { createQueryClient, queryPostRequest } from "hyperbridge-sdk"
 
 const queryClient = createQueryClient({
 	url: "http://localhost:3000", // URL of the Hyperbridge indexer API
@@ -103,7 +103,7 @@ const queryClient = createQueryClient({
 const commitmentHash = "0x...."
 
 // Get request statuses
-const request = await queryRequest({ commitmentHash, queryClient })
+const request = await queryPostRequest({ commitmentHash, queryClient })
 console.log(request.statuses) // read transaction statuses
 ```
 

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "hyperbridge-sdk",
-	"version": "1.0.0",
+	"version": "1.1.1",
 	"description": "The hyperclient SDK provides utilities for querying proofs and statuses for cross-chain requests from HyperBridge.",
 	"main": "dist/index.js",
 	"types": "dist/index.d.ts",

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -1,4 +1,5 @@
 export { IndexerClient } from "@/client"
+export { createQueryClient, queryGetRequest, queryPostRequest } from "@/query-client"
 export { postRequestCommitment } from "@/utils"
 export * from "@/utils/tokenGateway"
 export * from "@/utils/xcmGateway"


### PR DESCRIPTION
chore: exposed `queryPostRequest`, `queryGetRquest` and `createQueryClient`