### PR TITLE
Decode state machine ids correctly in substrate handlers

### DIFF
--- a/packages/indexer/src/handlers/events/substrateChains/handleRequestEvent.handler.ts
+++ b/packages/indexer/src/handlers/events/substrateChains/handleRequestEvent.handler.ts
@@ -15,22 +15,15 @@ export async function handleSubstrateRequestEvent(event: SubstrateEvent): Promis
 
 	const [dest_chain, source_chain, request_nonce, commitment] = event.event.data
 
-	logger.info(
-		`Handling ISMP Request Event: ${JSON.stringify({
-			source_chain,
-			dest_chain,
-			request_nonce,
-			commitment,
-		})}`,
-	)
-
 	const sourceId = formatChain(source_chain.toString())
 	const destId = formatChain(dest_chain.toString())
 
 	logger.info(
-		`Chain Ids: ${JSON.stringify({
+		`Handling ISMP Request Event: ${JSON.stringify({
 			sourceId,
 			destId,
+			request_nonce,
+			commitment,
 		})}`,
 	)
 

--- a/packages/indexer/src/handlers/events/substrateChains/handleResponseEvent.handler.ts
+++ b/packages/indexer/src/handlers/events/substrateChains/handleResponseEvent.handler.ts
@@ -15,23 +15,16 @@ export async function handleSubstrateResponseEvent(event: SubstrateEvent): Promi
 
 	const [dest_chain, source_chain, request_nonce, commitment, req_commitment] = event.event.data
 
-	logger.info(
-		`Handling ISMP Response Event: ${JSON.stringify({
-			source_chain,
-			dest_chain,
-			request_nonce,
-			commitment,
-			req_commitment,
-		})}`,
-	)
-
 	const sourceId = formatChain(source_chain.toString())
 	const destId = formatChain(dest_chain.toString())
 
 	logger.info(
-		`Chain Ids: ${JSON.stringify({
+		`Handling ISMP Response Event: ${JSON.stringify({
 			sourceId,
 			destId,
+			request_nonce,
+			commitment,
+			req_commitment,
 		})}`,
 	)
 

--- a/packages/indexer/src/utils/substrate.helpers.ts
+++ b/packages/indexer/src/utils/substrate.helpers.ts
@@ -86,7 +86,9 @@ export const formatChain = (chain: any) => {
 	const chainType = Object.keys(chainObj)[0]
 	if (chainType) {
 		// Convert chainType to uppercase and combine with chain ID
-		return `${chainType.toUpperCase()}-${chainObj[chainType]}`
+		const rawChainId = chainObj[chainType]
+		const id = rawChainId.startsWith("0x") ? Buffer.from(rawChainId.slice(2), "hex").toString() : String(rawChainId)
+		return `${chainType.toUpperCase()}-${id}`
 	}
 	return chain
 }

--- a/packages/indexer/src/utils/substrate.helpers.ts
+++ b/packages/indexer/src/utils/substrate.helpers.ts
@@ -87,7 +87,10 @@ export const formatChain = (chain: any) => {
 	if (chainType) {
 		// Convert chainType to uppercase and combine with chain ID
 		const rawChainId = chainObj[chainType]
-		const id = rawChainId.startsWith("0x") ? Buffer.from(rawChainId.slice(2), "hex").toString() : String(rawChainId)
+		let id = String(rawChainId)
+		if (typeof rawChainId === "string" && rawChainId.startsWith?.("0x")) {
+			id = Buffer.from(rawChainId.slice(2), "hex").toString()
+		}
 		return `${chainType.toUpperCase()}-${id}`
 	}
 	return chain


### PR DESCRIPTION
Decode state machine identifiers correctly in substrate events to avoid the error seen in the image below
![image](https://github.com/user-attachments/assets/74e77855-4020-4b90-93d4-41c51a760d8c)
