### PR TITLE
Improv: volume service

### DIFF
--- a/packages/indexer/src/configs/schema.graphql
+++ b/packages/indexer/src/configs/schema.graphql
@@ -1095,3 +1095,25 @@ type CumulativeVolumeUSD @entity {
 	"""
 	volumeUSD: String!
 }
+
+type DailyVolumeUSD @entity {
+	"""
+	Unique identifier for the cumulative stats
+	"""
+	id: ID!
+
+	"""
+	Last updated at
+	"""
+	lastUpdatedAt: BigInt!
+
+	"""
+	The timestamp when this record was created
+	"""
+	createdAt: Date!
+
+	"""
+	Last 24hrs Volume in USD
+	"""
+	last24HoursVolumeUSD: String!
+}

--- a/packages/indexer/src/services/__tests__/volume.service.test.ts
+++ b/packages/indexer/src/services/__tests__/volume.service.test.ts
@@ -1,0 +1,307 @@
+import Decimal from "decimal.js"
+
+import { CumulativeVolumeUSD, DailyVolumeUSD } from "@/configs/src/types"
+import { timestampToDate } from "@/utils/date.helpers"
+
+import { VolumeService } from "../volume.service"
+
+const mockStore = new Map<string, any>()
+
+// Mock the global store
+;(global as any).store = {
+	get: jest.fn().mockImplementation((entityName: string, id: string) => {
+		const key = `${entityName}:${id}`
+		return Promise.resolve(mockStore.get(key))
+	}),
+	set: jest.fn().mockImplementation((entityName: string, id: string, entity: any) => {
+		const key = `${entityName}:${id}`
+		mockStore.set(key, entity)
+		return Promise.resolve()
+	}),
+	remove: jest.fn().mockImplementation((entityName: string, id: string) => {
+		const key = `${entityName}:${id}`
+		mockStore.delete(key)
+		return Promise.resolve()
+	}),
+}
+
+// Mock the model classes
+jest.mock("@/configs/src/types", () => ({
+	CumulativeVolumeUSD: {
+		get: jest.fn().mockImplementation((id: string) => {
+			const key = `CumulativeVolumeUSD:${id}`
+			const data = mockStore.get(key)
+			if (data) {
+				return Promise.resolve({
+					id: data.id,
+					volumeUSD: data.volumeUSD,
+					lastUpdatedAt: data.lastUpdatedAt,
+					save: jest.fn().mockImplementation(function (this: any) {
+						const key = `CumulativeVolumeUSD:${this.id}`
+						mockStore.set(key, this)
+						return Promise.resolve()
+					}),
+				})
+			}
+			return Promise.resolve(undefined)
+		}),
+		create: jest.fn().mockImplementation((data: any) => {
+			const entity = {
+				id: data.id,
+				volumeUSD: data.volumeUSD,
+				lastUpdatedAt: data.lastUpdatedAt,
+				save: jest.fn().mockImplementation(function (this: any) {
+					const key = `CumulativeVolumeUSD:${this.id}`
+					mockStore.set(key, this)
+					return Promise.resolve()
+				}),
+			}
+			return entity
+		}),
+	},
+	DailyVolumeUSD: {
+		get: jest.fn().mockImplementation((id: string) => {
+			const key = `DailyVolumeUSD:${id}`
+			const data = mockStore.get(key)
+			if (data) {
+				return Promise.resolve({
+					id: data.id,
+					last24HoursVolumeUSD: data.last24HoursVolumeUSD,
+					lastUpdatedAt: data.lastUpdatedAt,
+					createdAt: data.createdAt,
+					save: jest.fn().mockImplementation(function (this: any) {
+						const key = `DailyVolumeUSD:${this.id}`
+						mockStore.set(key, this)
+						return Promise.resolve()
+					}),
+				})
+			}
+			return Promise.resolve(undefined)
+		}),
+		create: jest.fn().mockImplementation((data: any) => {
+			const entity = {
+				id: data.id,
+				last24HoursVolumeUSD: data.last24HoursVolumeUSD,
+				lastUpdatedAt: data.lastUpdatedAt,
+				createdAt: data.createdAt,
+				save: jest.fn().mockImplementation(function (this: any) {
+					const key = `DailyVolumeUSD:${this.id}`
+					mockStore.set(key, this)
+					return Promise.resolve()
+				}),
+			}
+			return entity
+		}),
+	},
+}))
+
+describe("VolumeService", () => {
+	beforeEach(() => {
+		// Clear the mock store before each test
+		mockStore.clear()
+		jest.clearAllMocks()
+	})
+
+	afterAll(() => {
+		mockStore.clear()
+		jest.clearAllMocks()
+	})
+
+	describe("updateCumulativeVolume", () => {
+		it("should create a new cumulative volume record when none exists", async () => {
+			const id = "TokenGateway"
+			const volume = "1000.50"
+			const timestamp = BigInt(1700000000)
+
+			await VolumeService.updateCumulativeVolume(id, volume, timestamp)
+
+			expect(CumulativeVolumeUSD.get).toHaveBeenCalledWith(id)
+			expect(CumulativeVolumeUSD.create).toHaveBeenCalledWith({
+				id,
+				volumeUSD: new Decimal(volume).toFixed(18),
+				lastUpdatedAt: timestamp,
+			})
+		})
+
+		it("should update existing cumulative volume record", async () => {
+			const id = "TokenGateway"
+			const volume = "500.25"
+			const additionalVolume = "200.75"
+			const timestamp = BigInt(1700000000)
+			const updatedTimestamp = BigInt(1700000100)
+
+			await VolumeService.updateCumulativeVolume(id, volume, timestamp)
+			await VolumeService.updateCumulativeVolume(id, additionalVolume, updatedTimestamp)
+
+			const stored = mockStore.get(`CumulativeVolumeUSD:${id}`)
+			expect(stored).toBeDefined()
+			expect(stored.volumeUSD).toBe("701.000000000000000000")
+			expect(stored.lastUpdatedAt).toBe(updatedTimestamp)
+		})
+
+		it("should handle decimal precision correctly", async () => {
+			const id = "TokenGateway"
+			await VolumeService.updateCumulativeVolume(id, "0.123456789012345678", BigInt(1700000000))
+
+			const stored = mockStore.get(`CumulativeVolumeUSD:${id}`)
+			expect(stored).toBeDefined()
+			expect(stored.volumeUSD).toBe("0.123456789012345678")
+		})
+	})
+
+	describe("updateDailyVolume", () => {
+		it("should create a new daily volume record when none exists", async () => {
+			const id = "TokenGateway"
+			const volume = "1000.50"
+			const timestamp = BigInt(1752145126274)
+
+			await VolumeService.updateDailyVolume(id, volume, timestamp)
+
+			const expectedId = `${id}.2025-07-10`
+			expect(DailyVolumeUSD.get).toHaveBeenCalledWith(expectedId)
+			expect(DailyVolumeUSD.create).toHaveBeenCalledWith({
+				id: expectedId,
+				last24HoursVolumeUSD: new Decimal(volume).toFixed(18),
+				lastUpdatedAt: timestamp,
+				createdAt: timestampToDate(timestamp),
+			})
+		})
+
+		it("should update existing daily volume record within 24 hours", async () => {
+			const id = "TokenGateway"
+			const volume = "500.25"
+			const additionalVolume = "200.75"
+			const timestamp = BigInt(1752145126274)
+			const updatedTimestamp = timestamp + BigInt(3600)
+
+			await VolumeService.updateDailyVolume(id, volume, timestamp)
+			await VolumeService.updateDailyVolume(id, additionalVolume, updatedTimestamp)
+
+			const stored = mockStore.get(`DailyVolumeUSD:${id}.2025-07-10`)
+			expect(stored).toBeDefined()
+			expect(stored.last24HoursVolumeUSD).toBe(
+				new Decimal(volume).plus(additionalVolume).toFixed(18),
+			)
+			expect(stored.lastUpdatedAt).toBe(updatedTimestamp)
+		})
+
+		it("should create new daily volume record after 24 hours", async () => {
+			const id = "TokenGateway"
+			const volume = "5000.25"
+			const additionalVolume = "2100.75"
+			const firstDayTimestamp = BigInt(1752495664445)
+			const secondDayTimestamp = firstDayTimestamp + BigInt(60 * 60 * 25 * 1000) // 25 hours later
+
+			await VolumeService.updateDailyVolume(id, volume, firstDayTimestamp)
+			await VolumeService.updateDailyVolume(id, additionalVolume, secondDayTimestamp)
+
+			const firstDayStored = mockStore.get(`DailyVolumeUSD:${id}.2025-07-14`)
+			expect(firstDayStored).toBeDefined()
+			expect(firstDayStored.last24HoursVolumeUSD).toBe(new Decimal(volume).toFixed(18))
+
+			const secondDayStored = mockStore.get(`DailyVolumeUSD:${id}.2025-07-15`)
+			expect(secondDayStored).toBeDefined()
+			expect(secondDayStored.last24HoursVolumeUSD).toBe(new Decimal(additionalVolume).toFixed(18))
+		})
+
+		it("should generate correct daily record ID based on timestamp", async () => {
+			const id = "TokenGateway"
+			await VolumeService.updateDailyVolume(id, "1000.50", BigInt(1752145126274))
+			expect(DailyVolumeUSD.get).toHaveBeenCalledWith(`${id}.2025-07-10`)
+		})
+	})
+
+	describe("updateVolume", () => {
+		it("should update both cumulative and daily volume", async () => {
+			const id = "TokenGateway"
+			const volume = "1000.50"
+			const timestamp = BigInt(1752497885694)
+
+			await VolumeService.updateVolume(id, volume, timestamp)
+
+			expect(CumulativeVolumeUSD.get).toHaveBeenCalledWith(id)
+			expect(CumulativeVolumeUSD.create).toHaveBeenCalledWith({
+				id,
+				volumeUSD: new Decimal(volume).toFixed(18),
+				lastUpdatedAt: timestamp,
+			})
+
+			const expectedDailyId = `${id}.2025-07-14`
+			expect(DailyVolumeUSD.get).toHaveBeenCalledWith(expectedDailyId)
+			expect(DailyVolumeUSD.create).toHaveBeenCalledWith({
+				id: expectedDailyId,
+				last24HoursVolumeUSD: new Decimal(volume).toFixed(18),
+				lastUpdatedAt: timestamp,
+				createdAt: timestampToDate(timestamp),
+			})
+		})
+
+		it("should handle parallel updates correctly", async () => {
+			const id = "TokenGateway"
+			const volume = "1000.50"
+			const timestamp = BigInt(1700000000)
+
+			const promises = [
+				VolumeService.updateVolume(id, volume, timestamp),
+				VolumeService.updateVolume(id, volume, timestamp),
+				VolumeService.updateVolume(id, volume, timestamp),
+			]
+
+			await Promise.all(promises)
+
+			expect(CumulativeVolumeUSD.get).toHaveBeenCalledTimes(3)
+			expect(DailyVolumeUSD.get).toHaveBeenCalledTimes(3)
+		})
+	})
+
+	describe("edge cases", () => {
+		it("should handle very large volume amounts", async () => {
+			const id = "TokenGateway"
+			const volume = "999999999999999999.999999999999999999"
+			const timestamp = BigInt(1700000000)
+
+			await VolumeService.updateCumulativeVolume(id, volume, timestamp)
+			const stored = mockStore.get(`CumulativeVolumeUSD:${id}`)
+
+			expect(stored).toBeDefined()
+			expect(stored.volumeUSD).toBe(new Decimal(volume).toFixed(18))
+		})
+
+		it("should handle zero volume amounts", async () => {
+			const id = "TokenGateway"
+			const volume = "0"
+			const timestamp = BigInt(1700000000)
+
+			await VolumeService.updateCumulativeVolume(id, volume, timestamp)
+			const stored = mockStore.get(`CumulativeVolumeUSD:${id}`)
+
+			expect(stored).toBeDefined()
+			expect(stored.volumeUSD).toBe("0.000000000000000000")
+		})
+
+		it("should handle very small volume amounts", async () => {
+			const id = "TokenGateway"
+      const volume = "0.000000000000000001"
+
+			await VolumeService.updateCumulativeVolume(id, volume, BigInt(1700000000))
+			const stored = mockStore.get(`CumulativeVolumeUSD:${id}`)
+
+			expect(stored).toBeDefined()
+			expect(stored.volumeUSD).toBe(new Decimal(volume).toFixed(18))
+		})
+
+		it("should handle different ID formats", async () => {
+			const ids = ["TokenGateway", "IntentGateway.USER", "IntentGateway.FILLER"]
+			const volume = "100.50"
+			const timestamp = BigInt(1700000000)
+
+			for (const id of ids) {
+				await VolumeService.updateCumulativeVolume(id, volume, BigInt(1700000000))
+				const stored = mockStore.get(`CumulativeVolumeUSD:${id}`)
+
+				expect(stored).toBeDefined()
+				expect(stored.volumeUSD).toBe(new Decimal(volume).toFixed(18))
+			}
+		})
+	})
+})

--- a/packages/indexer/src/services/intentGateway.service.ts
+++ b/packages/indexer/src/services/intentGateway.service.ts
@@ -1,19 +1,16 @@
-import { OrderPlaced } from "@/configs/src/types/models/OrderPlaced"
-import {
-	CumulativeVolumeUSD,
-	OrderStatus,
-	OrderStatusMetadata,
-	ProtocolParticipant,
-	RewardPointsActivityType,
-} from "@/configs/src/types"
-import PriceHelper from "@/utils/price.helpers"
-import { timestampToDate } from "@/utils/date.helpers"
-import { ERC6160Ext20Abi__factory } from "@/configs/src/types/contracts"
-import { hexToBytes, bytesToHex, keccak256, encodeAbiParameters } from "viem"
-import type { Hex } from "viem"
 import Decimal from "decimal.js"
-import { PointsService } from "./points.service"
 import { ethers } from "ethers"
+import type { Hex } from "viem"
+import { hexToBytes, bytesToHex, keccak256, encodeAbiParameters } from "viem"
+
+import { OrderStatus, OrderStatusMetadata, ProtocolParticipant, RewardPointsActivityType } from "@/configs/src/types"
+import { ERC6160Ext20Abi__factory } from "@/configs/src/types/contracts"
+import { OrderPlaced } from "@/configs/src/types/models/OrderPlaced"
+import { timestampToDate } from "@/utils/date.helpers"
+import PriceHelper from "@/utils/price.helpers"
+
+import { PointsService } from "./points.service"
+import { VolumeService } from "./volume.service"
 
 export interface TokenInfo {
 	token: Hex
@@ -93,21 +90,7 @@ export class IntentGatewayService {
 				timestamp,
 			)
 
-			// Count the volume in USD
-			let cumulativeVolumeUSD = await CumulativeVolumeUSD.get(`IntentGateway.USER`)
-			if (cumulativeVolumeUSD) {
-				cumulativeVolumeUSD.volumeUSD = new Decimal(cumulativeVolumeUSD.volumeUSD)
-					.plus(new Decimal(inputUSD))
-					.toFixed(18)
-			} else {
-				cumulativeVolumeUSD = await CumulativeVolumeUSD.create({
-					id: "cumulativeVolumeUSD",
-					volumeUSD: new Decimal(inputUSD).toFixed(18),
-					lastUpdatedAt: timestamp,
-				})
-			}
-
-			await cumulativeVolumeUSD.save()
+			await VolumeService.updateVolume("IntentGateway.USER", inputUSD, timestamp)
 		}
 
 		return orderPlaced
@@ -201,8 +184,6 @@ export class IntentGatewayService {
 					timestamp,
 				)
 
-				// Count the volume in USD
-				let cumulativeVolumeUSD = await CumulativeVolumeUSD.get(`IntentGateway.FILLER`)
 				let outputPaymentInfo: PaymentInfo[] = orderPlaced.outputTokens.map((token, index) => {
 					return {
 						token: token as Hex,
@@ -211,18 +192,7 @@ export class IntentGatewayService {
 					}
 				})
 				let outputUSD = await this.getOutputValuesUSD(outputPaymentInfo)
-				if (cumulativeVolumeUSD) {
-					cumulativeVolumeUSD.volumeUSD = new Decimal(cumulativeVolumeUSD.volumeUSD)
-						.plus(new Decimal(outputUSD.total))
-						.toFixed(18)
-				} else {
-					cumulativeVolumeUSD = await CumulativeVolumeUSD.create({
-						id: `IntentGateway.FILLER`,
-						volumeUSD: new Decimal(outputUSD.total).toFixed(18),
-						lastUpdatedAt: timestamp,
-					})
-				}
-				await cumulativeVolumeUSD.save()
+				await VolumeService.updateVolume("IntentGateway.FILLER", outputUSD.total, timestamp)
 			}
 
 			// Deduct points when order is cancelled

--- a/packages/indexer/src/services/volume.service.ts
+++ b/packages/indexer/src/services/volume.service.ts
@@ -1,0 +1,111 @@
+import Decimal from "decimal.js"
+
+import { CumulativeVolumeUSD, DailyVolumeUSD } from "@/configs/src/types"
+import { timestampToDate } from "@/utils/date.helpers"
+
+export class VolumeService {
+	private static readonly TWENTY_FOUR_HOURS_IN_MS = 24 * 60 * 60 * 1000
+	private static readonly TWENTY_FOUR_HOURS_IN_SECONDS = 24 * 60 * 60
+
+	/**
+	 * Update cumulative volume for a given identifier
+	 * @param id - The identifier for the cumulative volume record
+	 * @param volumeUSD - The volume in USD to add
+	 * @param timestamp - The timestamp of the transaction
+	 */
+	static async updateCumulativeVolume(id: string, volumeUSD: string, timestamp: bigint): Promise<void> {
+		let cumulativeVolumeUSD = await CumulativeVolumeUSD.get(id)
+
+		if (cumulativeVolumeUSD) {
+			cumulativeVolumeUSD.volumeUSD = new Decimal(cumulativeVolumeUSD.volumeUSD)
+				.plus(new Decimal(volumeUSD))
+				.toFixed(18)
+			cumulativeVolumeUSD.lastUpdatedAt = timestamp
+		} else {
+			cumulativeVolumeUSD = await CumulativeVolumeUSD.create({
+				id,
+				volumeUSD: new Decimal(volumeUSD).toFixed(18),
+				lastUpdatedAt: timestamp,
+			})
+		}
+
+		await cumulativeVolumeUSD.save()
+	}
+
+	/**
+	 * Update daily volume for a given identifier
+	 * Creates a new record every 24 hours
+	 * @param id - The base identifier for the daily volume record
+	 * @param volumeUSD - The volume in USD to add
+	 * @param timestamp - The timestamp of the transaction
+	 */
+	static async updateDailyVolume(id: string, volumeUSD: string, timestamp: bigint): Promise<void> {
+		const dailyRecordId = this.getDailyRecordId(id, timestamp)
+		let dailyVolumeUSD = await DailyVolumeUSD.get(dailyRecordId)
+
+		if (dailyVolumeUSD) {
+			// Check if the existing record is still within 24 hours
+			if (this.isWithin24Hours(dailyVolumeUSD.lastUpdatedAt, timestamp)) {
+				// Update existing record
+				dailyVolumeUSD.last24HoursVolumeUSD = new Decimal(dailyVolumeUSD.last24HoursVolumeUSD)
+					.plus(new Decimal(volumeUSD))
+					.toFixed(18)
+				dailyVolumeUSD.lastUpdatedAt = timestamp
+			} else {
+				// Create new record for the new 24-hour period
+				dailyVolumeUSD = await DailyVolumeUSD.create({
+					id: dailyRecordId,
+					last24HoursVolumeUSD: new Decimal(volumeUSD).toFixed(18),
+					lastUpdatedAt: timestamp,
+					createdAt: timestampToDate(timestamp),
+				})
+			}
+		} else {
+			// Create new record
+			dailyVolumeUSD = await DailyVolumeUSD.create({
+				id: dailyRecordId,
+				last24HoursVolumeUSD: new Decimal(volumeUSD).toFixed(18),
+				lastUpdatedAt: timestamp,
+				createdAt: timestampToDate(timestamp),
+			})
+		}
+
+		await dailyVolumeUSD.save()
+	}
+
+	/**
+	 * Update both cumulative and daily volume in a single call
+	 * @param id - The identifier for the volume records
+	 * @param volumeUSD - The volume in USD to add
+	 * @param timestamp - The timestamp of the transaction
+	 */
+	static async updateVolume(id: string, volumeUSD: string, timestamp: bigint): Promise<void> {
+		await Promise.all([
+			this.updateCumulativeVolume(id, volumeUSD, timestamp),
+			this.updateDailyVolume(id, volumeUSD, timestamp),
+		])
+	}
+
+	/**
+	 * Generate a daily record ID based on the base ID and timestamp
+	 * @param baseId - The base identifier
+	 * @param timestamp - The timestamp
+	 * @returns The daily record ID
+	 */
+	private static getDailyRecordId(baseId: string, timestamp: bigint): string {
+		const date = timestampToDate(timestamp)
+		const dateString = date.toISOString().split("T")[0] // Get YYYY-MM-DD format
+		return `${baseId}.${dateString}`
+	}
+
+	/**
+	 * Check if a timestamp is within 24 hours of another timestamp
+	 * @param lastUpdatedAt - The last updated timestamp
+	 * @param currentTimestamp - The current timestamp
+	 * @returns True if within 24 hours, false otherwise
+	 */
+	private static isWithin24Hours(lastUpdatedAt: bigint, currentTimestamp: bigint): boolean {
+		const timeDiffInSeconds = Number(currentTimestamp - lastUpdatedAt)
+		return timeDiffInSeconds < this.TWENTY_FOUR_HOURS_IN_SECONDS
+	}
+}

--- a/packages/indexer/src/services/volume.service.ts
+++ b/packages/indexer/src/services/volume.service.ts
@@ -2,6 +2,7 @@ import Decimal from "decimal.js"
 
 import { CumulativeVolumeUSD, DailyVolumeUSD } from "@/configs/src/types"
 import { timestampToDate } from "@/utils/date.helpers"
+import { getHostStateMachine } from "@/utils/substrate.helpers"
 
 export class VolumeService {
 	/**
@@ -78,11 +79,11 @@ export class VolumeService {
 
 	/**
 	 * Generate a entity record ID base on the base ID (getDailyRecordId inclusive) and chainId
-	 * @param baseId
-	 * @returns
+	 * @param baseId - The identifier for the volume record
 	 */
 	static getChainTypeId(baseId: string): string {
-		return `${baseId}.${chainId}`
+		const stateMachineId = getHostStateMachine(chainId)
+		return `${baseId}.${stateMachineId}`
 	}
 
 	/**

--- a/packages/indexer/src/services/volume.service.ts
+++ b/packages/indexer/src/services/volume.service.ts
@@ -105,7 +105,7 @@ export class VolumeService {
 	 * @returns True if within 24 hours, false otherwise
 	 */
 	private static isWithin24Hours(createdAt: Date, currentTimestamp: bigint): boolean {
-		const timestampDate = new Date(Number(currentTimestamp)).toISOString().split("T")[0]
+		const timestampDate = timestampToDate(currentTimestamp).toISOString().split("T")[0]
 		const createdDate = createdAt.toISOString().split("T")[0]
 		return timestampDate <= createdDate
 	}

--- a/packages/indexer/src/services/volume.service.ts
+++ b/packages/indexer/src/services/volume.service.ts
@@ -4,9 +4,6 @@ import { CumulativeVolumeUSD, DailyVolumeUSD } from "@/configs/src/types"
 import { timestampToDate } from "@/utils/date.helpers"
 
 export class VolumeService {
-	private static readonly TWENTY_FOUR_HOURS_IN_MS = 24 * 60 * 60 * 1000
-	private static readonly TWENTY_FOUR_HOURS_IN_SECONDS = 24 * 60 * 60
-
 	/**
 	 * Update cumulative volume for a given identifier
 	 * @param id - The identifier for the cumulative volume record
@@ -16,17 +13,19 @@ export class VolumeService {
 	static async updateCumulativeVolume(id: string, volumeUSD: string, timestamp: bigint): Promise<void> {
 		let cumulativeVolumeUSD = await CumulativeVolumeUSD.get(id)
 
-		if (cumulativeVolumeUSD) {
-			cumulativeVolumeUSD.volumeUSD = new Decimal(cumulativeVolumeUSD.volumeUSD)
-				.plus(new Decimal(volumeUSD))
-				.toFixed(18)
-			cumulativeVolumeUSD.lastUpdatedAt = timestamp
-		} else {
-			cumulativeVolumeUSD = await CumulativeVolumeUSD.create({
+		if (!cumulativeVolumeUSD) {
+			cumulativeVolumeUSD = CumulativeVolumeUSD.create({
 				id,
 				volumeUSD: new Decimal(volumeUSD).toFixed(18),
 				lastUpdatedAt: timestamp,
 			})
+		}
+
+		if (cumulativeVolumeUSD.lastUpdatedAt !== timestamp) {
+			cumulativeVolumeUSD.volumeUSD = new Decimal(cumulativeVolumeUSD.volumeUSD)
+				.plus(new Decimal(volumeUSD))
+				.toFixed(18)
+			cumulativeVolumeUSD.lastUpdatedAt = timestamp
 		}
 
 		await cumulativeVolumeUSD.save()
@@ -43,31 +42,20 @@ export class VolumeService {
 		const dailyRecordId = this.getDailyRecordId(id, timestamp)
 		let dailyVolumeUSD = await DailyVolumeUSD.get(dailyRecordId)
 
-		if (dailyVolumeUSD) {
-			// Check if the existing record is still within 24 hours
-			if (this.isWithin24Hours(dailyVolumeUSD.lastUpdatedAt, timestamp)) {
-				// Update existing record
-				dailyVolumeUSD.last24HoursVolumeUSD = new Decimal(dailyVolumeUSD.last24HoursVolumeUSD)
-					.plus(new Decimal(volumeUSD))
-					.toFixed(18)
-				dailyVolumeUSD.lastUpdatedAt = timestamp
-			} else {
-				// Create new record for the new 24-hour period
-				dailyVolumeUSD = await DailyVolumeUSD.create({
-					id: dailyRecordId,
-					last24HoursVolumeUSD: new Decimal(volumeUSD).toFixed(18),
-					lastUpdatedAt: timestamp,
-					createdAt: timestampToDate(timestamp),
-				})
-			}
-		} else {
-			// Create new record
-			dailyVolumeUSD = await DailyVolumeUSD.create({
+		if (!dailyVolumeUSD) {
+			dailyVolumeUSD = DailyVolumeUSD.create({
 				id: dailyRecordId,
 				last24HoursVolumeUSD: new Decimal(volumeUSD).toFixed(18),
 				lastUpdatedAt: timestamp,
 				createdAt: timestampToDate(timestamp),
 			})
+		}
+
+		if (this.isWithin24Hours(dailyVolumeUSD.createdAt, timestamp) && dailyVolumeUSD.lastUpdatedAt !== timestamp) {
+			dailyVolumeUSD.last24HoursVolumeUSD = new Decimal(dailyVolumeUSD.last24HoursVolumeUSD)
+				.plus(new Decimal(volumeUSD))
+				.toFixed(18)
+			dailyVolumeUSD.lastUpdatedAt = timestamp
 		}
 
 		await dailyVolumeUSD.save()
@@ -100,12 +88,13 @@ export class VolumeService {
 
 	/**
 	 * Check if a timestamp is within 24 hours of another timestamp
-	 * @param lastUpdatedAt - The last updated timestamp
+	 * @param createdAt - The date the record was created
 	 * @param currentTimestamp - The current timestamp
 	 * @returns True if within 24 hours, false otherwise
 	 */
-	private static isWithin24Hours(lastUpdatedAt: bigint, currentTimestamp: bigint): boolean {
-		const timeDiffInSeconds = Number(currentTimestamp - lastUpdatedAt)
-		return timeDiffInSeconds < this.TWENTY_FOUR_HOURS_IN_SECONDS
+	private static isWithin24Hours(createdAt: Date, currentTimestamp: bigint): boolean {
+		const timestampDate = new Date(Number(currentTimestamp)).toISOString().split("T")[0]
+		const createdDate = createdAt.toISOString().split("T")[0]
+		return timestampDate <= createdDate
 	}
 }

--- a/packages/indexer/src/services/volume.service.ts
+++ b/packages/indexer/src/services/volume.service.ts
@@ -6,11 +6,12 @@ import { timestampToDate } from "@/utils/date.helpers"
 export class VolumeService {
 	/**
 	 * Update cumulative volume for a given identifier
-	 * @param id - The identifier for the cumulative volume record
+	 * @param baseId - The identifier for the cumulative volume record
 	 * @param volumeUSD - The volume in USD to add
 	 * @param timestamp - The timestamp of the transaction
 	 */
-	static async updateCumulativeVolume(id: string, volumeUSD: string, timestamp: bigint): Promise<void> {
+	static async updateCumulativeVolume(baseId: string, volumeUSD: string, timestamp: bigint): Promise<void> {
+		const id = this.getChainTypeId(baseId)
 		let cumulativeVolumeUSD = await CumulativeVolumeUSD.get(id)
 
 		if (!cumulativeVolumeUSD) {
@@ -34,11 +35,12 @@ export class VolumeService {
 	/**
 	 * Update daily volume for a given identifier
 	 * Creates a new record every 24 hours
-	 * @param id - The base identifier for the daily volume record
+	 * @param baseId - The base identifier for the daily volume record
 	 * @param volumeUSD - The volume in USD to add
 	 * @param timestamp - The timestamp of the transaction
 	 */
-	static async updateDailyVolume(id: string, volumeUSD: string, timestamp: bigint): Promise<void> {
+	static async updateDailyVolume(baseId: string, volumeUSD: string, timestamp: bigint): Promise<void> {
+		const id = this.getChainTypeId(baseId)
 		const dailyRecordId = this.getDailyRecordId(id, timestamp)
 		let dailyVolumeUSD = await DailyVolumeUSD.get(dailyRecordId)
 
@@ -72,6 +74,15 @@ export class VolumeService {
 			this.updateCumulativeVolume(id, volumeUSD, timestamp),
 			this.updateDailyVolume(id, volumeUSD, timestamp),
 		])
+	}
+
+	/**
+	 * Generate a entity record ID base on the base ID (getDailyRecordId inclusive) and chainId
+	 * @param baseId
+	 * @returns
+	 */
+	static getChainTypeId(baseId: string): string {
+		return `${baseId}.${chainId}`
 	}
 
 	/**


### PR DESCRIPTION
This PR introduces a centralized `VolumeService` to streamline volume tracking across the indexer and adds support for daily volume metrics alongside existing cumulative tracking.

### Key Changes

**New Features:**
- **Daily Volume Tracking**: Added `DailyVolumeUSD` entity to track 24-hour volume windows
- **Centralized Volume Service**: Created `VolumeService` to handle all volume-related operations
- **Unified Volume API**: Single `updateVolume()` method updates both cumulative and daily metrics

**Refactoring:**
- **Asset Received Handler**: Replaced inline volume logic with `VolumeService.updateVolume()`
- **Intent Gateway Service**: Removed duplicate volume tracking code for both USER and FILLER operations
- **Code Deduplication**: Eliminated scattered volume calculation logic across multiple files

**Schema Updates:**
- Added `DailyVolumeUSD` entity with fields: `id`, `lastUpdatedAt`, `createdAt`, `last24HoursVolumeUSD`
- Maintains existing `CumulativeVolumeUSD` functionality

**Testing:**
- Comprehensive test suite covering edge cases (large amounts, zero values, precision handling)
- Tests for both cumulative and daily volume operations
- Parallel update handling and ID format validation