### PR TITLE
fix: zkverify-testnet state machine ID for testnet config

### DIFF
--- a/packages/indexer/src/configs/config-testnet.json
+++ b/packages/indexer/src/configs/config-testnet.json
@@ -15,7 +15,7 @@
   	"type": "substrate",
   	"chainId": "0xff7fe5a610f15fe7a0c52f94f86313fb7db7d3786e7f8acf2b66c11d5be7c242",
   	"startBlock": 1,
-  	"stateMachineId": "KUSAMA-zkv_"
+  	"stateMachineId": "SUBSTRATE-zkv_"
 	},
 	"kilt-paseo": {
   	"type": "substrate",


### PR DESCRIPTION
### Summary
Corrects the state machine identifier for zkverify-testnet from `KUSAMA-zkv_` to `SUBSTRATE-zkv_`.

### Changes
- Updated `stateMachineId` in `config-testnet.json` for zkverify-testnet chain
- Changed from incorrect `KUSAMA-zkv_` prefix to proper `SUBSTRATE-zkv_` prefix