### PR TITLE
feature: track relayer metadata and last updated timestamps

### DIFF
--- a/packages/indexer/src/configs/schema.graphql
+++ b/packages/indexer/src/configs/schema.graphql
@@ -214,7 +214,7 @@ type Relayer @entity {
 	"""
 	Last updated at
 	"""
-	lastUpdatedAt: BigInt!
+	lastUpdatedAt: BigInt
 }
 
 """

--- a/packages/indexer/src/configs/schema.graphql
+++ b/packages/indexer/src/configs/schema.graphql
@@ -210,6 +210,11 @@ type Relayer @entity {
 	A list of important stats for the Relayer on every network that they support
 	"""
 	perChainStats: [RelayerStatsPerChain]! @derivedFrom(field: "relayer")
+
+	"""
+	Last updated at
+	"""
+	lastUpdatedAt: BigInt!
 }
 
 """

--- a/packages/indexer/src/handlers/events/evmHost/getRequestHandled.event.handler.ts
+++ b/packages/indexer/src/handlers/events/evmHost/getRequestHandled.event.handler.ts
@@ -26,7 +26,7 @@ export const handleGetRequestHandledEvent = wrap(async (event: GetRequestHandled
 	const chain = getHostStateMachine(chainId)
 	const blockTimestamp = await getBlockTimestamp(blockHash, chain)
 
-	await HyperBridgeService.handlePostRequestOrResponseHandledEvent(relayer_id, chain)
+	await HyperBridgeService.handlePostRequestOrResponseHandledEvent(relayer_id, chain, blockTimestamp)
 
 	await GetRequestService.updateStatus({
 		commitment,

--- a/packages/indexer/src/handlers/events/evmHost/postRequestHandled.event.handler.ts
+++ b/packages/indexer/src/handlers/events/evmHost/postRequestHandled.event.handler.ts
@@ -27,7 +27,7 @@ export const handlePostRequestHandledEvent = wrap(async (event: PostRequestHandl
 	const blockTimestamp = await getBlockTimestamp(blockHash, chain)
 
 	try {
-		await HyperBridgeService.handlePostRequestOrResponseHandledEvent(relayer_id, chain)
+		await HyperBridgeService.handlePostRequestOrResponseHandledEvent(relayer_id, chain, blockTimestamp)
 
 		await RequestService.updateStatus({
 			commitment,

--- a/packages/indexer/src/handlers/events/evmHost/postResponseHandled.event.handler.ts
+++ b/packages/indexer/src/handlers/events/evmHost/postResponseHandled.event.handler.ts
@@ -27,7 +27,7 @@ export const handlePostResponseHandledEvent = wrap(async (event: PostResponseHan
 	const blockTimestamp = await getBlockTimestamp(blockHash, chain)
 
 	try {
-		await HyperBridgeService.handlePostRequestOrResponseHandledEvent(relayer_id, chain)
+		await HyperBridgeService.handlePostRequestOrResponseHandledEvent(relayer_id, chain, blockTimestamp)
 
 		await ResponseService.updateStatus({
 			commitment,

--- a/packages/indexer/src/handlers/events/substrateChains/handleGetRequestHandledEvent.handler.ts
+++ b/packages/indexer/src/handlers/events/substrateChains/handleGetRequestHandledEvent.handler.ts
@@ -49,7 +49,7 @@ export const handleSubstrateGetRequestHandledEvent = wrap(async (event: Substrat
 	}
 
 	logger.info(`Updating Hyperbridge chain stats for ${host}`)
-	await HyperBridgeService.handlePostRequestOrResponseHandledEvent(relayer_id, host)
+	await HyperBridgeService.handlePostRequestOrResponseHandledEvent(relayer_id, host, blockTimestamp)
 
 	await GetRequestService.updateStatus({
 		commitment: eventData.commitment.toString(),

--- a/packages/indexer/src/handlers/events/substrateChains/handlePostRequestHandledEvent.handler.ts
+++ b/packages/indexer/src/handlers/events/substrateChains/handlePostRequestHandledEvent.handler.ts
@@ -49,7 +49,7 @@ export const handleSubstratePostRequestHandledEvent = wrap(async (event: Substra
 	}
 
 	logger.info(`Updating Hyperbridge chain stats for ${host}`)
-	await HyperBridgeService.handlePostRequestOrResponseHandledEvent(relayer_id, host)
+	await HyperBridgeService.handlePostRequestOrResponseHandledEvent(relayer_id, host, blockTimestamp)
 
 	logger.info(
 		`Handling ISMP PostRequestHandled Event: ${stringify({

--- a/packages/indexer/src/handlers/events/substrateChains/handlePostResponseHandledEvent.handler.ts
+++ b/packages/indexer/src/handlers/events/substrateChains/handlePostResponseHandledEvent.handler.ts
@@ -52,7 +52,7 @@ export const handleSubstratePostResponseHandledEvent = wrap(async (event: Substr
 	}
 
 	logger.info(`Updating Hyperbridge chain stats for ${host}`)
-	await HyperBridgeService.handlePostRequestOrResponseHandledEvent(relayer_id, host)
+	await HyperBridgeService.handlePostRequestOrResponseHandledEvent(relayer_id, host, blockTimestamp)
 
 	logger.info(
 		`Handling ISMP PostRequestHandled Event: ${stringify({

--- a/packages/indexer/src/handlers/events/tokenGateway/assetTeleported.event.handler.ts
+++ b/packages/indexer/src/handlers/events/tokenGateway/assetTeleported.event.handler.ts
@@ -5,6 +5,8 @@ import { TokenGatewayService } from "@/services/tokenGateway.service"
 import { TeleportStatus } from "@/configs/src/types"
 import { getHostStateMachine, isSubstrateChain } from "@/utils/substrate.helpers"
 import { wrap } from "@/utils/event.utils"
+import { VolumeService } from "@/services/volume.service"
+import PriceHelper from "@/utils/price.helpers"
 
 export const handleAssetTeleportedEvent = wrap(async (event: AssetTeleportedLog): Promise<void> => {
 	logger.info(`Asset Teleported Event: ${stringify(event)}`)
@@ -16,6 +18,14 @@ export const handleAssetTeleportedEvent = wrap(async (event: AssetTeleportedLog)
 	const timestamp = await getBlockTimestamp(blockHash, chain)
 
 	if (isSubstrateChain(dest)) {
+		const tokenContract = await TokenGatewayService.getAssetTokenContract(assetId.toString())
+		const decimals = await tokenContract.decimals()
+		const symbol = await tokenContract.symbol()
+
+		const usdValue = await PriceHelper.getTokenPriceInUSDCoingecko(symbol, amount.toBigInt(), decimals)
+
+		await VolumeService.updateVolume("TokenGateway", usdValue.amountValueInUSD, timestamp)
+
 		logger.info(`Skipping teleport to substrate chain: ${dest}`)
 		return
 	}

--- a/packages/indexer/src/services/hyperbridge.service.ts
+++ b/packages/indexer/src/services/hyperbridge.service.ts
@@ -41,9 +41,13 @@ export class HyperBridgeService {
 	/**
 	 * Perform the necessary actions related to Hyperbridge stats when a PostRequestHandled/PostResponseHandled event is indexed
 	 */
-	static async handlePostRequestOrResponseHandledEvent(relayer_id: string, chain: string): Promise<void> {
+	static async handlePostRequestOrResponseHandledEvent(
+		relayer_id: string,
+		chain: string,
+		timestamp: bigint,
+	): Promise<void> {
 		await this.incrementNumberOfDeliveredMessages(chain)
-		await RelayerService.updateMessageDelivered(relayer_id, chain)
+		await RelayerService.updateMessageDelivered(relayer_id, chain, timestamp)
 	}
 
 	//  /**

--- a/packages/indexer/src/services/hyperbridge.service.ts
+++ b/packages/indexer/src/services/hyperbridge.service.ts
@@ -3,6 +3,7 @@ import { Relayer, Transfer } from "@/configs/src/types/models"
 import { HyperBridgeChainStatsService } from "@/services/hyperbridgeChainStats.service"
 import { isHexString } from "ethers/lib/utils"
 import { EthereumHostAbi__factory } from "@/configs/src/types/contracts"
+import { RelayerService } from "./relayer.service"
 // import {
 //  HandlePostRequestsTransaction,
 //  HandlePostResponsesTransaction,
@@ -40,8 +41,9 @@ export class HyperBridgeService {
 	/**
 	 * Perform the necessary actions related to Hyperbridge stats when a PostRequestHandled/PostResponseHandled event is indexed
 	 */
-	static async handlePostRequestOrResponseHandledEvent(_relayer_id: string, chain: string): Promise<void> {
+	static async handlePostRequestOrResponseHandledEvent(relayer_id: string, chain: string): Promise<void> {
 		await this.incrementNumberOfDeliveredMessages(chain)
+		await RelayerService.updateMessageDelivered(relayer_id, chain)
 	}
 
 	//  /**

--- a/packages/indexer/src/services/relayer.service.ts
+++ b/packages/indexer/src/services/relayer.service.ts
@@ -42,6 +42,23 @@ export class RelayerService {
 		}
 	}
 
+	/**
+	 * Update message delivered by the relayer
+	 * @param relayer_id The relayer address
+	 * @param chain The chain identifier
+	 */
+	static async updateMessageDelivered(relayer_id: string, chain: string): Promise<void> {
+		let relayer = await this.findOrCreate(relayer_id, chain)
+		if (relayer) {
+			let relayer_chain_stats = await RelayerChainStatsService.findOrCreate(relayer.id, chain)
+
+			relayer_chain_stats.numberOfSuccessfulMessagesDelivered += BigInt(1)
+
+			await relayer.save()
+			await relayer_chain_stats.save()
+		}
+	}
+
 	//  /**
 	//   * Computes relayer specific stats from the handlePostRequest/handlePostResponse transactions on the handlerV1 contract
 	//   */

--- a/packages/indexer/src/test/events/erc6160ext20/transfer.event.handler.test.ts
+++ b/packages/indexer/src/test/events/erc6160ext20/transfer.event.handler.test.ts
@@ -4,7 +4,6 @@ import { Relayer, Transfer } from "@/configs/src/types"
 const existingEntities = [
 	Relayer.create({
 		id: "0xbC50b90751bfCccbFa4c7220261909d0f528b00f",
-		lastUpdatedAt: BigInt(0),
 	}),
 ]
 
@@ -19,10 +18,6 @@ subqlTest(
 			amount: BigInt("24000000000000000000000"),
 			from: "0x92F217a5e965EAa2aD356678D537A0A9ccC0AF41",
 			to: "0xbC50b90751bfCccbFa4c7220261909d0f528b00f",
-		}),
-		Relayer.create({
-			id: "0xbC50b90751bfCccbFa4c7220261909d0f528b00f",
-			lastUpdatedAt: BigInt(0),
 		}),
 	],
 	"handleTransferEvent",

--- a/packages/indexer/src/test/events/erc6160ext20/transfer.event.handler.test.ts
+++ b/packages/indexer/src/test/events/erc6160ext20/transfer.event.handler.test.ts
@@ -4,6 +4,7 @@ import { Relayer, Transfer } from "@/configs/src/types"
 const existingEntities = [
 	Relayer.create({
 		id: "0xbC50b90751bfCccbFa4c7220261909d0f528b00f",
+		lastUpdatedAt: BigInt(0),
 	}),
 ]
 
@@ -18,6 +19,10 @@ subqlTest(
 			amount: BigInt("24000000000000000000000"),
 			from: "0x92F217a5e965EAa2aD356678D537A0A9ccC0AF41",
 			to: "0xbC50b90751bfCccbFa4c7220261909d0f528b00f",
+		}),
+		Relayer.create({
+			id: "0xbC50b90751bfCccbFa4c7220261909d0f528b00f",
+			lastUpdatedAt: BigInt(0),
 		}),
 	],
 	"handleTransferEvent",


### PR DESCRIPTION
This PR enhances relayer statistics tracking metadata updates for successful message deliveries and timestamp.

Closes: #42 #30 

### Changes

**Schema Updates:**
- Added `lastUpdatedAt: BigInt!` field to the `Relayer` entity to track when relayer data was last modified

**Enhanced Relayer Service:**
- Added new `updateMessageDelivered()` method that:
  - Increments `numberOfSuccessfulMessagesDelivered` counter for relayers

### Extras
- Increment Volume Count for substrate transactions via asset teleported @Wizdave97
