### PR TITLE
chore: bump sdk version to 1.1.9

### DIFF
--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "hyperbridge-sdk",
-	"version": "1.1.8",
+	"version": "1.1.9",
 	"description": "The hyperclient SDK provides utilities for querying proofs and statuses for cross-chain requests from HyperBridge.",
 	"type": "module",
 	"types": "./dist/node/index.d.ts",


### PR DESCRIPTION
- Fixes timeout proof issues with eth_getProof on EVM networks
- Changes state machine update query to use descending order