### PR TITLE
chore: add aggregate transaction with commitment feature

### DIFF
--- a/packages/sdk/src/client.ts
+++ b/packages/sdk/src/client.ts
@@ -1554,8 +1554,11 @@ export class IndexerClient {
 	/**
 	 * Aggregate transactions with commitment.
 	 * @param commitment
+	 * @returns an object containing the transaction hash, block hash, block number, timestamp.
 	 */
-	async aggregateTransactionWithCommitment(commitment: HexString) {
+	async aggregateTransactionWithCommitment(
+		commitment: HexString,
+	): Promise<Awaited<ReturnType<SubstrateChain["submitUnsigned"]>>> {
 		const logger = this.logger.withTag("aggregateTransactionWithCommitment")
 
 		const { stateMachineId, consensusStateId } = this.config.source


### PR DESCRIPTION
This PR introduces a new method `aggregateTransactionWithCommitment()` to the `IndexerClient` class, enabling aggregation of cross-chain transactions using commitment hashes.

### Feature
- Aggregate Transactions With Commitment Hash for Processing on `Hyperbridge`
- Handles edge case where transactions aren't picked up by Relayers.