### PR TITLE
chore(sdk): update package name to @hyperbridge/sdk

### DIFF
--- a/.github/workflows/publish-sdk.yml
+++ b/.github/workflows/publish-sdk.yml
@@ -32,12 +32,12 @@ jobs:
               run: pnpm install
 
             - name: Build SDK
-              run: pnpm --filter="hyperbridge-sdk" build
+              run: pnpm --filter="@hyperbridge/sdk" build
 
             - name: Publish to npm
               run: |
                   echo "//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}" > ~/.npmrc
-                  pnpm --filter="hyperbridge-sdk" publish --no-git-checks
+                  pnpm --filter="@hyperbridge/sdk" publish --no-git-checks
               env:
                   NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 

--- a/.github/workflows/test-sdk.yml
+++ b/.github/workflows/test-sdk.yml
@@ -103,7 +103,7 @@ jobs:
                   sleep 10  # Give it a few more seconds to fully initialize
 
             - name: Run SDK tests
-              run: pnpm --filter="hyperbridge-sdk" test
+              run: pnpm --filter="@hyperbridge/sdk" test
 
             - name: Run Intent Filler tests
               run: pnpm --filter="filler" test

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
 		"packages/*"
 	],
 	"scripts": {
-		"build": "pnpm --filter=\"hyperbridge-sdk\" build && pnpm --filter=\"@hyperbridge/indexer\" build && pnpm --filter=\"@hyperbridge/filler\" build",
+		"build": "pnpm --filter=\"@hyperbridge/sdk\" build && pnpm --filter=\"@hyperbridge/indexer\" build && pnpm --filter=\"@hyperbridge/filler\" build",
 		"test": "pnpm --filter=\"*\" test",
 		"lint": "pnpm --filter=\"*\" lint",
 		"format": "pnpm --filter=\"*\" format",

--- a/packages/filler/package.json
+++ b/packages/filler/package.json
@@ -42,6 +42,7 @@
 		"node": ">=18.0.0"
 	},
 	"dependencies": {
+		"@hyperbridge/sdk": "workspace:*",
 		"@polkadot/api": "^15.9.1",
 		"@polkadot/util-crypto": "^13.4.4",
 		"@safe-global/api-kit": "^3.0.1",
@@ -50,7 +51,6 @@
 		"ckb-mmr-wasm": "link:wasm-b",
 		"dotenv": "^16.4.7",
 		"ethers": "^5.7.2",
-		"hyperbridge-sdk": "workspace:*",
 		"p-queue": "^8.1.0",
 		"scale-ts": "^1.6.1",
 		"viem": "^2.23.5"

--- a/packages/filler/pnpm-lock.yaml
+++ b/packages/filler/pnpm-lock.yaml
@@ -1,19 +1,22 @@
 lockfileVersion: '9.0'
 
 settings:
-  autoInstallPeers: true
+  autoInstallPeers: false
   excludeLinksFromLockfile: false
 
 importers:
 
   .:
     dependencies:
+      '@hyperbridge/sdk':
+        specifier: workspace:*
+        version: link:../sdk
       '@polkadot/api':
         specifier: ^15.9.1
         version: 15.9.1
       '@polkadot/util-crypto':
         specifier: ^13.4.4
-        version: 13.4.4(@polkadot/util@13.4.4)
+        version: 13.4.4
       '@safe-global/api-kit':
         specifier: ^3.0.1
         version: 3.0.1(typescript@5.8.3)
@@ -32,9 +35,6 @@ importers:
       ethers:
         specifier: ^5.7.2
         version: 5.8.0
-      hyperbridge-sdk:
-        specifier: workspace:*
-        version: link:../sdk
       p-queue:
         specifier: ^8.1.0
         version: 8.1.0
@@ -481,7 +481,6 @@ packages:
     resolution: {integrity: sha512-pIm+u1lat+mGUABsCZyTm1/qgwL3NS94SC7TPtSzhzFZq6faUFNMyq1gBfTicrb7MjGFc8FlrKlGxFtudnQC9Q==}
     engines: {node: '>=18'}
     peerDependencies:
-      '@polkadot/util': 13.4.4
       '@polkadot/util-crypto': 13.4.4
 
   '@polkadot/networks@13.4.4':
@@ -527,8 +526,6 @@ packages:
   '@polkadot/util-crypto@13.4.4':
     resolution: {integrity: sha512-xuXBNdK3Axlj1ItR6n1kH9zgaDNWri9pb/w1HDFx89bHvw6Bl79wA/oHtVGLbHZ1y/bunpsuapznyswhnsaVog==}
     engines: {node: '>=18'}
-    peerDependencies:
-      '@polkadot/util': 13.4.4
 
   '@polkadot/util@13.4.4':
     resolution: {integrity: sha512-Lveu+8pZLBoAyyv+8X7FI4aTOwLaNXRc9gz1wVaUoGzk5VgmKp/qbPg0a+mfJD8usjf748OVbShhjXvhV3MLiA==}
@@ -2027,7 +2024,7 @@ snapshots:
       '@polkadot/types': 15.9.1
       '@polkadot/types-codec': 15.9.1
       '@polkadot/util': 13.4.4
-      '@polkadot/util-crypto': 13.4.4(@polkadot/util@13.4.4)
+      '@polkadot/util-crypto': 13.4.4
       rxjs: 7.8.2
       tslib: 2.8.1
     transitivePeerDependencies:
@@ -2040,7 +2037,7 @@ snapshots:
       '@polkadot/api-augment': 15.9.1
       '@polkadot/api-base': 15.9.1
       '@polkadot/api-derive': 15.9.1
-      '@polkadot/keyring': 13.4.4(@polkadot/util-crypto@13.4.4(@polkadot/util@13.4.4))(@polkadot/util@13.4.4)
+      '@polkadot/keyring': 13.4.4(@polkadot/util-crypto@13.4.4)
       '@polkadot/rpc-augment': 15.9.1
       '@polkadot/rpc-core': 15.9.1
       '@polkadot/rpc-provider': 15.9.1
@@ -2050,7 +2047,7 @@ snapshots:
       '@polkadot/types-create': 15.9.1
       '@polkadot/types-known': 15.9.1
       '@polkadot/util': 13.4.4
-      '@polkadot/util-crypto': 13.4.4(@polkadot/util@13.4.4)
+      '@polkadot/util-crypto': 13.4.4
       eventemitter3: 5.0.1
       rxjs: 7.8.2
       tslib: 2.8.1
@@ -2059,10 +2056,10 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@polkadot/keyring@13.4.4(@polkadot/util-crypto@13.4.4(@polkadot/util@13.4.4))(@polkadot/util@13.4.4)':
+  '@polkadot/keyring@13.4.4(@polkadot/util-crypto@13.4.4)':
     dependencies:
       '@polkadot/util': 13.4.4
-      '@polkadot/util-crypto': 13.4.4(@polkadot/util@13.4.4)
+      '@polkadot/util-crypto': 13.4.4
       tslib: 2.8.1
 
   '@polkadot/networks@13.4.4':
@@ -2098,11 +2095,11 @@ snapshots:
 
   '@polkadot/rpc-provider@15.9.1':
     dependencies:
-      '@polkadot/keyring': 13.4.4(@polkadot/util-crypto@13.4.4(@polkadot/util@13.4.4))(@polkadot/util@13.4.4)
+      '@polkadot/keyring': 13.4.4(@polkadot/util-crypto@13.4.4)
       '@polkadot/types': 15.9.1
       '@polkadot/types-support': 15.9.1
       '@polkadot/util': 13.4.4
-      '@polkadot/util-crypto': 13.4.4(@polkadot/util@13.4.4)
+      '@polkadot/util-crypto': 13.4.4
       '@polkadot/x-fetch': 13.4.4
       '@polkadot/x-global': 13.4.4
       '@polkadot/x-ws': 13.4.4
@@ -2152,16 +2149,16 @@ snapshots:
 
   '@polkadot/types@15.9.1':
     dependencies:
-      '@polkadot/keyring': 13.4.4(@polkadot/util-crypto@13.4.4(@polkadot/util@13.4.4))(@polkadot/util@13.4.4)
+      '@polkadot/keyring': 13.4.4(@polkadot/util-crypto@13.4.4)
       '@polkadot/types-augment': 15.9.1
       '@polkadot/types-codec': 15.9.1
       '@polkadot/types-create': 15.9.1
       '@polkadot/util': 13.4.4
-      '@polkadot/util-crypto': 13.4.4(@polkadot/util@13.4.4)
+      '@polkadot/util-crypto': 13.4.4
       rxjs: 7.8.2
       tslib: 2.8.1
 
-  '@polkadot/util-crypto@13.4.4(@polkadot/util@13.4.4)':
+  '@polkadot/util-crypto@13.4.4':
     dependencies:
       '@noble/curves': 1.8.1
       '@noble/hashes': 1.7.1

--- a/packages/filler/src/core/event-monitor.ts
+++ b/packages/filler/src/core/event-monitor.ts
@@ -6,7 +6,7 @@ import {
 	DUMMY_PRIVATE_KEY,
 	hexToString,
 	DecodedOrderPlacedLog,
-} from "hyperbridge-sdk"
+} from "@hyperbridge/sdk"
 import { INTENT_GATEWAY_ABI } from "@/config/abis/IntentGateway"
 import { PublicClient } from "viem"
 import { addresses } from "@/config/chain"

--- a/packages/filler/src/core/filler.ts
+++ b/packages/filler/src/core/filler.ts
@@ -1,7 +1,7 @@
 import { chainIds } from "@/config/chain"
 import { EventMonitor } from "./event-monitor"
 import { FillerStrategy } from "@/strategies/base"
-import { Order, FillerConfig, ChainConfig, DUMMY_PRIVATE_KEY, ADDRESS_ZERO, bytes20ToBytes32 } from "hyperbridge-sdk"
+import { Order, FillerConfig, ChainConfig, DUMMY_PRIVATE_KEY, ADDRESS_ZERO, bytes20ToBytes32 } from "@hyperbridge/sdk"
 import pQueue from "p-queue"
 import { ChainClientManager, ChainConfigService, ContractInteractionService } from "@/services"
 import { fetchTokenUsdPriceOnchain } from "@/utils"
@@ -76,7 +76,7 @@ export class IntentFiller {
 					orderValue,
 				)
 				console.log(
-					`For order ${order.id}, required confirmations: ${requiredConfirmations}, 
+					`For order ${order.id}, required confirmations: ${requiredConfirmations},
 					current confirmations: ${currentConfirmations}`,
 				)
 

--- a/packages/filler/src/services/ChainClientManager.ts
+++ b/packages/filler/src/services/ChainClientManager.ts
@@ -1,6 +1,6 @@
 import { PublicClient, WalletClient, createPublicClient, createWalletClient, http, type Chain } from "viem"
 import { privateKeyToAccount } from "viem/accounts"
-import { Order, HexString, ChainConfig } from "hyperbridge-sdk"
+import { Order, HexString, ChainConfig } from "@hyperbridge/sdk"
 import { ChainConfigService } from "./ChainConfigService"
 import { viemChains } from "@/config/chain"
 

--- a/packages/filler/src/services/ChainConfigService.ts
+++ b/packages/filler/src/services/ChainConfigService.ts
@@ -1,5 +1,5 @@
 import { toHex } from "viem"
-import { ChainConfig, HexString } from "hyperbridge-sdk"
+import { ChainConfig, HexString } from "@hyperbridge/sdk"
 import {
 	addresses,
 	assets,

--- a/packages/filler/src/services/ContractInteractionService.ts
+++ b/packages/filler/src/services/ContractInteractionService.ts
@@ -15,13 +15,13 @@ import {
 	bytes20ToBytes32,
 	EvmLanguage,
 	calculateBalanceMappingLocation,
-} from "hyperbridge-sdk"
+} from "@hyperbridge/sdk"
 import { ERC20_ABI } from "@/config/abis/ERC20"
 import { ChainClientManager } from "./ChainClientManager"
 import { ChainConfigService } from "./ChainConfigService"
 import { INTENT_GATEWAY_ABI } from "@/config/abis/IntentGateway"
 import { EVM_HOST } from "@/config/abis/EvmHost"
-import { orderCommitment } from "hyperbridge-sdk"
+import { orderCommitment } from "@hyperbridge/sdk"
 import { ApiPromise, WsProvider } from "@polkadot/api"
 import { fetchTokenUsdPriceOnchain } from "@/utils"
 import { keccakAsU8a } from "@polkadot/util-crypto"

--- a/packages/filler/src/strategies/base.ts
+++ b/packages/filler/src/strategies/base.ts
@@ -1,4 +1,4 @@
-import { Order, FillerConfig, ExecutionResult } from "hyperbridge-sdk"
+import { Order, FillerConfig, ExecutionResult } from "@hyperbridge/sdk"
 export interface FillerStrategy {
 	name: string
 

--- a/packages/filler/src/strategies/basic.ts
+++ b/packages/filler/src/strategies/basic.ts
@@ -7,7 +7,7 @@ import {
 	estimateGasForPost,
 	constructRedeemEscrowRequestBody,
 	IPostRequest,
-} from "hyperbridge-sdk"
+} from "@hyperbridge/sdk"
 import { INTENT_GATEWAY_ABI } from "@/config/abis/IntentGateway"
 import { privateKeyToAccount, privateKeyToAddress } from "viem/accounts"
 import { ChainClientManager, ChainConfigService, ContractInteractionService } from "@/services"

--- a/packages/filler/src/strategies/swap.ts
+++ b/packages/filler/src/strategies/swap.ts
@@ -1,5 +1,5 @@
 import { ChainConfigService, ChainClientManager, ContractInteractionService } from "@/services"
-import { ADDRESS_ZERO, bytes32ToBytes20, ExecutionResult, FillOptions, HexString, Order } from "hyperbridge-sdk"
+import { ADDRESS_ZERO, bytes32ToBytes20, ExecutionResult, FillOptions, HexString, Order } from "@hyperbridge/sdk"
 import { FillerStrategy } from "./base"
 import { privateKeyToAddress } from "viem/accounts"
 import { INTENT_GATEWAY_ABI } from "@/config/abis/IntentGateway"

--- a/packages/filler/src/tests/filler.test.ts
+++ b/packages/filler/src/tests/filler.test.ts
@@ -18,7 +18,7 @@ import {
 	ADDRESS_ZERO,
 	bytes32ToBytes20,
 	postRequestCommitment,
-} from "hyperbridge-sdk"
+} from "@hyperbridge/sdk"
 import { describe, it, expect } from "vitest"
 import { ConfirmationPolicy } from "@/config/confirmation-policy"
 import {

--- a/packages/filler/src/tests/sdk-imports.test.ts
+++ b/packages/filler/src/tests/sdk-imports.test.ts
@@ -1,4 +1,4 @@
-import { __test } from 'hyperbridge-sdk';
+import { __test } from '@hyperbridge/sdk';
 
 it("should load test function and invoke without failure", async () => {
 	expect(await __test()).toMatchInlineSnapshot(`"{"root":"0x85835c4d5287fe023073eb733f4e4103935d61b4397f0f9d0fe627d434757fa5","proof":["0x894376e04f932deadc9ab212ac514f37b41e670be2f8002babde1faf20935461","0xf3ace1896f86f91627cc1c09eeaba2cd76d82a75be6f09b94c861524fa5e5289","0x0ffa0900c838d17341df2d00fa4832755de619e646137844700668ad544c8aae","0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470","0x9c6b2c1b0d0b25a008e6c882cc7b415f309965c72ad2b944ac0931048ca31cd5","0xfadbd3c7f79fa2bdc4f24857709cd4a4e870623dc9e9abcdfd6e448033e35212"],"mmr_size":236,"leaf_positions":[232],"keccak_hash_calldata":"0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470"}"`);

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -5,11 +5,11 @@ A JavaScript/TypeScript SDK for interacting with the Hyperbridge indexer and mon
 ## Installation
 
 ```bash
-npm install hyperbridge-sdk
+npm install @hyperbridge/sdk
 # or
-yarn add hyperbridge-sdk
+yarn add @hyperbridge/sdk
 # or
-pnpm add hyperbridge-sdk
+pnpm add @hyperbridge/sdk
 ```
 
 ## Usage
@@ -17,7 +17,7 @@ pnpm add hyperbridge-sdk
 ### Initialize Client
 
 ```ts
-import { IndexerClient, createQueryClient } from "hyperbridge-sdk"
+import { IndexerClient, createQueryClient } from "@hyperbridge/sdk"
 
 const queryClient = createQueryClient({
 	url: "http://localhost:3000", // URL of the Hyperbridge indexer API
@@ -49,7 +49,7 @@ const indexer = new IndexerClient({
 ### Monitor Post Request Status
 
 ```ts
-import { postRequestCommitment } from "hyperbridge-sdk"
+import { postRequestCommitment } from "@hyperbridge/sdk"
 
 // Get status stream for a commitment
 const commitment = postRequestCommitment(request)
@@ -94,7 +94,7 @@ console.log(request?.statuses)
 Alternatively. You can use the `queryPostRequest` utility
 
 ```ts
-import { createQueryClient, queryPostRequest } from "hyperbridge-sdk"
+import { createQueryClient, queryPostRequest } from "@hyperbridge/sdk"
 
 const queryClient = createQueryClient({
 	url: "http://localhost:3000", // URL of the Hyperbridge indexer API
@@ -110,7 +110,7 @@ console.log(request.statuses) // read transaction statuses
 ### Chain Utilities
 
 ```ts
-import { EvmChain, SubstrateChain } from "hyperbridge-sdk"
+import { EvmChain, SubstrateChain } from "@hyperbridge/sdk"
 
 // Interact with EVM chains
 const evmChain = new EvmChain({
@@ -137,7 +137,7 @@ If you're using Vite in your project, Hyperbridge SDK includes a plugin to handl
 ```ts
 // vite.config.ts
 import { defineConfig } from "vite"
-import hyperbridge from "hyperbridge-sdk/plugins/vite"
+import hyperbridge from "@hyperbridge/sdk/plugins/vite"
 
 export default defineConfig({
 	plugins: [

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,5 +1,5 @@
 {
-	"name": "hyperbridge-sdk",
+	"name": "@hyperbridge/sdk",
 	"version": "1.1.10",
 	"description": "The hyperclient SDK provides utilities for querying proofs and statuses for cross-chain requests from HyperBridge.",
 	"type": "module",
@@ -44,6 +44,7 @@
 		"build:node": "tsup --config tsup-node.config.ts",
 		"build:browser": "tsup --config tsup-browser.config.ts",
 		"prepublishOnly": "npm run build",
+		"postinstall": "pnpm run build",
 		"test": "npm run test:concurrent && npm run test:sequence",
 		"test:file": "vitest --watch=false --maxConcurrency=1",
 		"test:concurrent": "vitest --watch=false --exclude=./src/tests/sequential",

--- a/packages/sdk/plugins/vite.d.ts
+++ b/packages/sdk/plugins/vite.d.ts
@@ -1,9 +1,9 @@
 import type { Plugin } from "vite"
 
 /**
- * A Vite plugin that copies the WebAssembly file from hyperbridge-sdk to the Vite cache directory.
+ * A Vite plugin that copies the WebAssembly file from @hyperbridge/sdk to the Vite cache directory.
  * This ensures the WASM file is available for browser imports when using Vite.
- * 
+ *
  * @returns {Plugin} A Vite plugin
  */
 export function copyWasm(): Plugin

--- a/packages/sdk/plugins/vite.js
+++ b/packages/sdk/plugins/vite.js
@@ -31,8 +31,8 @@ const copyWasm = () => {
 			// Get path to the consuming project's node_modules
 			const projectNodeModules = path.resolve(process.cwd(), "node_modules")
 
-			// Find the hyperbridge-sdk package in node_modules
-			const source = path.resolve(projectNodeModules, "hyperbridge-sdk/dist/browser/web_bg.wasm")
+			// Find the @hyperbridge/sdk package in node_modules
+			const source = path.resolve(projectNodeModules, "@hyperbridge/sdk/dist/browser/web_bg.wasm")
 
 			// Destination in the Vite cache directory
 			const destDir = path.resolve(projectNodeModules, ".vite/deps")

--- a/packages/sdk/pnpm-lock.yaml
+++ b/packages/sdk/pnpm-lock.yaml
@@ -1,7 +1,7 @@
 lockfileVersion: '9.0'
 
 settings:
-  autoInstallPeers: true
+  autoInstallPeers: false
   excludeLinksFromLockfile: false
 
 importers:
@@ -11,9 +11,6 @@ importers:
       '@async-generator/merge-race':
         specifier: ^1.0.3
         version: 1.0.3
-      '@hyperbridge/filler':
-        specifier: workspace:*
-        version: link:../filler
       '@polkadot/api':
         specifier: ^15.7.1
         version: 15.7.2
@@ -56,13 +53,13 @@ importers:
       viem:
         specifier: ^2.23.5
         version: 2.23.6(typescript@5.8.2)
-      vite:
-        specifier: ^5.0.0 || ^6.0.0
-        version: 6.3.5(@types/node@22.13.9)(jiti@2.4.2)(terser@5.39.0)
     devDependencies:
       '@biomejs/biome':
         specifier: ^1.9.4
         version: 1.9.4
+      '@hyperbridge/filler':
+        specifier: workspace:*
+        version: link:../filler
       '@polkadot/keyring':
         specifier: 13.4.3
         version: 13.4.3(@polkadot/util-crypto@13.3.1(@polkadot/util@13.3.1))(@polkadot/util@13.3.1)
@@ -74,7 +71,7 @@ importers:
         version: 22.13.9
       '@vitest/coverage-v8':
         specifier: ^3.1.4
-        version: 3.1.4(vitest@3.1.4(@types/node@22.13.9)(jiti@2.4.2)(jsdom@26.0.0)(terser@5.39.0))
+        version: 3.1.4(vitest@3.1.4(@types/node@22.13.9)(jsdom@26.0.0))
       dotenv:
         specifier: ^16.4.7
         version: 16.4.7
@@ -86,16 +83,16 @@ importers:
         version: 0.3.0
       tsup:
         specifier: ^8.4.0
-        version: 8.4.0(@swc/core@1.11.16)(jiti@2.4.2)(postcss@8.5.3)(typescript@5.8.2)
+        version: 8.4.0(postcss@8.5.3)(typescript@5.8.2)
       typescript:
         specifier: ^5.7.3
         version: 5.8.2
       vite-tsconfig-paths:
         specifier: ^5.1.4
-        version: 5.1.4(typescript@5.8.2)(vite@6.3.5(@types/node@22.13.9)(jiti@2.4.2)(terser@5.39.0))
+        version: 5.1.4(typescript@5.8.2)(vite@6.3.5(@types/node@22.13.9))
       vitest:
         specifier: ^3.1.4
-        version: 3.1.4(@types/node@22.13.9)(jiti@2.4.2)(jsdom@26.0.0)(terser@5.39.0)
+        version: 3.1.4(@types/node@22.13.9)(jsdom@26.0.0)
 
 packages:
 
@@ -391,9 +388,6 @@ packages:
   '@jridgewell/set-array@1.2.1':
     resolution: {integrity: sha512-R8gLRTZeyp03ymzP/6Lil/28tGeGEzhx1q2k703KGWRAI1VdvPIXdG70VJc2pAMw3NA6JKL5hhFu1sJX0Mnn/A==}
     engines: {node: '>=6.0.0'}
-
-  '@jridgewell/source-map@0.3.6':
-    resolution: {integrity: sha512-1ZJTZebgqllO79ue2bm3rIGud/bOe0pP5BjSRCRxxYkEZS8STV7zN84UBbiYu7jy+eCKSnVIUgoWWE/tt+shMQ==}
 
   '@jridgewell/sourcemap-codec@1.5.0':
     resolution: {integrity: sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ==}
@@ -764,81 +758,6 @@ packages:
   '@substrate/ss58-registry@1.51.0':
     resolution: {integrity: sha512-TWDurLiPxndFgKjVavCniytBIw+t4ViOi7TYp9h/D0NMmkEc9klFTo+827eyEJ0lELpqO207Ey7uGxUa+BS1jQ==}
 
-  '@swc/core-darwin-arm64@1.11.16':
-    resolution: {integrity: sha512-l6uWMU+MUdfLHCl3dJgtVEdsUHPskoA4BSu0L1hh9SGBwPZ8xeOz8iLIqZM27lTuXxL4KsYH6GQR/OdQ/vhLtg==}
-    engines: {node: '>=10'}
-    cpu: [arm64]
-    os: [darwin]
-
-  '@swc/core-darwin-x64@1.11.16':
-    resolution: {integrity: sha512-TH0IW8Ao1WZ4ARFHIh29dAQHYBEl4YnP74n++rjppmlCjY+8v3s5nXMA7IqxO3b5LVHyggWtU4+46DXTyMJM7g==}
-    engines: {node: '>=10'}
-    cpu: [x64]
-    os: [darwin]
-
-  '@swc/core-linux-arm-gnueabihf@1.11.16':
-    resolution: {integrity: sha512-2IxD9t09oNZrbv37p4cJ9cTHMUAK6qNiShi9s2FJ9LcqSnZSN4iS4hvaaX6KZuG54d58vWnMU7yycjkdOTQcMg==}
-    engines: {node: '>=10'}
-    cpu: [arm]
-    os: [linux]
-
-  '@swc/core-linux-arm64-gnu@1.11.16':
-    resolution: {integrity: sha512-AYkN23DOiPh1bf3XBf/xzZQDKSsgZTxlbyTyUIhprLJpAAAT0ZCGAUcS5mHqydk0nWQ13ABUymodvHoroutNzw==}
-    engines: {node: '>=10'}
-    cpu: [arm64]
-    os: [linux]
-
-  '@swc/core-linux-arm64-musl@1.11.16':
-    resolution: {integrity: sha512-n/nWXDRCIhM51dDGELfBcTMNnCiFatE7LDvsbYxb7DJt1HGjaCNvHHCKURb/apJTh/YNtWfgFap9dbsTgw8yPA==}
-    engines: {node: '>=10'}
-    cpu: [arm64]
-    os: [linux]
-
-  '@swc/core-linux-x64-gnu@1.11.16':
-    resolution: {integrity: sha512-xr182YQrF47n7Awxj+/ruI21bYw+xO/B26KFVnb+i3ezF9NOhqoqTX+33RL1ZLA/uFTq8ksPZO/y+ZVS/odtQA==}
-    engines: {node: '>=10'}
-    cpu: [x64]
-    os: [linux]
-
-  '@swc/core-linux-x64-musl@1.11.16':
-    resolution: {integrity: sha512-k2JBfiwWfXCIKrBRjFO9/vEdLSYq0QLJ+iNSLdfrejZ/aENNkbEg8O7O2GKUSb30RBacn6k8HMfJrcPLFiEyCQ==}
-    engines: {node: '>=10'}
-    cpu: [x64]
-    os: [linux]
-
-  '@swc/core-win32-arm64-msvc@1.11.16':
-    resolution: {integrity: sha512-taOb5U+abyEhQgex+hr6cI48BoqSvSdfmdirWcxprIEUBHCxa1dSriVwnJRAJOFI9T+5BEz88by6rgbB9MjbHA==}
-    engines: {node: '>=10'}
-    cpu: [arm64]
-    os: [win32]
-
-  '@swc/core-win32-ia32-msvc@1.11.16':
-    resolution: {integrity: sha512-b7yYggM9LBDiMY+XUt5kYWvs5sn0U3PXSOGvF3CbLufD/N/YQiDcYON2N3lrWHYL8aYnwbuZl45ojmQHSQPcdA==}
-    engines: {node: '>=10'}
-    cpu: [ia32]
-    os: [win32]
-
-  '@swc/core-win32-x64-msvc@1.11.16':
-    resolution: {integrity: sha512-/ibq/YDc3B5AROkpOKPGxVkSyCKOg+ml8k11RxrW7FAPy6a9y5y9KPcWIqV74Ahq4RuaMNslTQqHWAGSm0xJsQ==}
-    engines: {node: '>=10'}
-    cpu: [x64]
-    os: [win32]
-
-  '@swc/core@1.11.16':
-    resolution: {integrity: sha512-wgjrJqVUss8Lxqilg0vkiE0tkEKU3mZkoybQM1Ehy+PKWwwB6lFAwKi20cAEFlSSWo8jFR8hRo19ZELAoLDowg==}
-    engines: {node: '>=10'}
-    peerDependencies:
-      '@swc/helpers': '*'
-    peerDependenciesMeta:
-      '@swc/helpers':
-        optional: true
-
-  '@swc/counter@0.1.3':
-    resolution: {integrity: sha512-e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ==}
-
-  '@swc/types@0.1.21':
-    resolution: {integrity: sha512-2YEtj5HJVbKivud9N4bpPBAyZhj4S2Ipe5LkUG94alTpr7in/GU/EARgPAd3BwU+YOmFVJC2+kjqhGRi3r0ZpQ==}
-
   '@types/bn.js@5.1.6':
     resolution: {integrity: sha512-Xh8vSwUeMKeYYrj3cX4lGQgFSF/N03r+tv4AiLl1SucqV+uTQpxRcnM8AkXKHwYP9ZPXOYXRr2KPXpVlIvqh9w==}
 
@@ -903,11 +822,6 @@ packages:
       zod:
         optional: true
 
-  acorn@8.14.1:
-    resolution: {integrity: sha512-OvQ/2pUDKmgfCg++xsTX1wGxfTaszcHVcTctW4UJB4hibJx2HXxxO5UmVgyjMa+ZDsiaf5wWLXYpRWMmBI0QHg==}
-    engines: {node: '>=0.4.0'}
-    hasBin: true
-
   agent-base@7.1.3:
     resolution: {integrity: sha512-jRR5wdylq8CkOe6hei19GGZnxM6rBGwFl3Bg0YItGDimvjGtAvdZk4Pu6Cl4u4Igsws4a1fd1Vq3ezrhn4KmFw==}
     engines: {node: '>= 14'}
@@ -947,9 +861,6 @@ packages:
   brace-expansion@2.0.1:
     resolution: {integrity: sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==}
 
-  buffer-from@1.1.2:
-    resolution: {integrity: sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==}
-
   bundle-require@5.1.0:
     resolution: {integrity: sha512-3WrrOuZiyaaZPWiEt4G3+IffISVC9HYlWueJEBWED4ZH4aIAC2PnkdnuRrR94M+w6yGWn4AglWtJtBI8YqvgoA==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
@@ -986,9 +897,6 @@ packages:
   combined-stream@1.0.8:
     resolution: {integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==}
     engines: {node: '>= 0.8'}
-
-  commander@2.20.3:
-    resolution: {integrity: sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==}
 
   commander@4.1.1:
     resolution: {integrity: sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==}
@@ -1231,10 +1139,6 @@ packages:
   jackspeak@3.4.3:
     resolution: {integrity: sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==}
 
-  jiti@2.4.2:
-    resolution: {integrity: sha512-rg9zJN+G4n2nfJl5MW3BMygZX56zKPNVEYYqq7adpmMh4Jn2QNEwhvQlFy6jPVdcod7txZtKHWnyZiA3a0zP7A==}
-    hasBin: true
-
   joycon@3.1.1:
     resolution: {integrity: sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==}
     engines: {node: '>=10'}
@@ -1474,13 +1378,6 @@ packages:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
 
-  source-map-support@0.5.21:
-    resolution: {integrity: sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==}
-
-  source-map@0.6.1:
-    resolution: {integrity: sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==}
-    engines: {node: '>=0.10.0'}
-
   source-map@0.8.0-beta.0:
     resolution: {integrity: sha512-2ymg6oRBpebeZi9UUNsgQ89bhx01TcTkmNTGnNO88imTmbSgy4nfujrgVEFKWpMTEGA11EDkTt7mqObTPdigIA==}
     engines: {node: '>= 8'}
@@ -1518,11 +1415,6 @@ packages:
 
   symbol-tree@3.2.4:
     resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
-
-  terser@5.39.0:
-    resolution: {integrity: sha512-LBAhFyLho16harJoWMg/nZsQYgTrg5jXOn2nCYjRUcZZEdE3qa2zb8QEDRUGVZBW4rlazf2fxkg8tztybTaqWw==}
-    engines: {node: '>=10'}
-    hasBin: true
 
   test-exclude@7.0.1:
     resolution: {integrity: sha512-pFYqmTw68LXVjeWJMST4+borgQP2AyMNbg1BpZh9LbyhUeNkeaPF9gzfPGUAnSMV3qPYdWUwDIjjCLiSDOl7vg==}
@@ -2007,12 +1899,6 @@ snapshots:
 
   '@jridgewell/set-array@1.2.1': {}
 
-  '@jridgewell/source-map@0.3.6':
-    dependencies:
-      '@jridgewell/gen-mapping': 0.3.8
-      '@jridgewell/trace-mapping': 0.3.25
-    optional: true
-
   '@jridgewell/sourcemap-codec@1.5.0': {}
 
   '@jridgewell/trace-mapping@0.3.25':
@@ -2297,10 +2183,10 @@ snapshots:
       '@noble/hashes': 1.7.1
       '@polkadot/networks': 13.4.3
       '@polkadot/util': 13.4.3
-      '@polkadot/wasm-crypto': 7.4.1(@polkadot/util@13.4.3)(@polkadot/x-randomvalues@13.4.3(@polkadot/util@13.4.3)(@polkadot/wasm-util@7.4.1(@polkadot/util@13.3.1)))
+      '@polkadot/wasm-crypto': 7.4.1(@polkadot/util@13.4.3)(@polkadot/x-randomvalues@13.4.3(@polkadot/util@13.4.3)(@polkadot/wasm-util@7.4.1(@polkadot/util@13.4.3)))
       '@polkadot/wasm-util': 7.4.1(@polkadot/util@13.4.3)
       '@polkadot/x-bigint': 13.4.3
-      '@polkadot/x-randomvalues': 13.4.3(@polkadot/util@13.4.3)(@polkadot/wasm-util@7.4.1(@polkadot/util@13.3.1))
+      '@polkadot/x-randomvalues': 13.4.3(@polkadot/util@13.4.3)(@polkadot/wasm-util@7.4.1(@polkadot/util@13.4.3))
       '@scure/base': 1.2.4
       tslib: 2.8.1
 
@@ -2331,11 +2217,11 @@ snapshots:
       '@polkadot/x-randomvalues': 13.3.1(@polkadot/util@13.3.1)(@polkadot/wasm-util@7.4.1(@polkadot/util@13.3.1))
       tslib: 2.8.1
 
-  '@polkadot/wasm-bridge@7.4.1(@polkadot/util@13.4.3)(@polkadot/x-randomvalues@13.4.3(@polkadot/util@13.4.3)(@polkadot/wasm-util@7.4.1(@polkadot/util@13.3.1)))':
+  '@polkadot/wasm-bridge@7.4.1(@polkadot/util@13.4.3)(@polkadot/x-randomvalues@13.4.3(@polkadot/util@13.4.3)(@polkadot/wasm-util@7.4.1(@polkadot/util@13.4.3)))':
     dependencies:
       '@polkadot/util': 13.4.3
       '@polkadot/wasm-util': 7.4.1(@polkadot/util@13.4.3)
-      '@polkadot/x-randomvalues': 13.4.3(@polkadot/util@13.4.3)(@polkadot/wasm-util@7.4.1(@polkadot/util@13.3.1))
+      '@polkadot/x-randomvalues': 13.4.3(@polkadot/util@13.4.3)(@polkadot/wasm-util@7.4.1(@polkadot/util@13.4.3))
       tslib: 2.8.1
 
   '@polkadot/wasm-crypto-asmjs@7.4.1(@polkadot/util@13.3.1)':
@@ -2358,14 +2244,14 @@ snapshots:
       '@polkadot/x-randomvalues': 13.3.1(@polkadot/util@13.3.1)(@polkadot/wasm-util@7.4.1(@polkadot/util@13.3.1))
       tslib: 2.8.1
 
-  '@polkadot/wasm-crypto-init@7.4.1(@polkadot/util@13.4.3)(@polkadot/x-randomvalues@13.4.3(@polkadot/util@13.4.3)(@polkadot/wasm-util@7.4.1(@polkadot/util@13.3.1)))':
+  '@polkadot/wasm-crypto-init@7.4.1(@polkadot/util@13.4.3)(@polkadot/x-randomvalues@13.4.3(@polkadot/util@13.4.3)(@polkadot/wasm-util@7.4.1(@polkadot/util@13.4.3)))':
     dependencies:
       '@polkadot/util': 13.4.3
-      '@polkadot/wasm-bridge': 7.4.1(@polkadot/util@13.4.3)(@polkadot/x-randomvalues@13.4.3(@polkadot/util@13.4.3)(@polkadot/wasm-util@7.4.1(@polkadot/util@13.3.1)))
+      '@polkadot/wasm-bridge': 7.4.1(@polkadot/util@13.4.3)(@polkadot/x-randomvalues@13.4.3(@polkadot/util@13.4.3)(@polkadot/wasm-util@7.4.1(@polkadot/util@13.4.3)))
       '@polkadot/wasm-crypto-asmjs': 7.4.1(@polkadot/util@13.4.3)
       '@polkadot/wasm-crypto-wasm': 7.4.1(@polkadot/util@13.4.3)
       '@polkadot/wasm-util': 7.4.1(@polkadot/util@13.4.3)
-      '@polkadot/x-randomvalues': 13.4.3(@polkadot/util@13.4.3)(@polkadot/wasm-util@7.4.1(@polkadot/util@13.3.1))
+      '@polkadot/x-randomvalues': 13.4.3(@polkadot/util@13.4.3)(@polkadot/wasm-util@7.4.1(@polkadot/util@13.4.3))
       tslib: 2.8.1
 
   '@polkadot/wasm-crypto-wasm@7.4.1(@polkadot/util@13.3.1)':
@@ -2391,15 +2277,15 @@ snapshots:
       '@polkadot/x-randomvalues': 13.3.1(@polkadot/util@13.3.1)(@polkadot/wasm-util@7.4.1(@polkadot/util@13.3.1))
       tslib: 2.8.1
 
-  '@polkadot/wasm-crypto@7.4.1(@polkadot/util@13.4.3)(@polkadot/x-randomvalues@13.4.3(@polkadot/util@13.4.3)(@polkadot/wasm-util@7.4.1(@polkadot/util@13.3.1)))':
+  '@polkadot/wasm-crypto@7.4.1(@polkadot/util@13.4.3)(@polkadot/x-randomvalues@13.4.3(@polkadot/util@13.4.3)(@polkadot/wasm-util@7.4.1(@polkadot/util@13.4.3)))':
     dependencies:
       '@polkadot/util': 13.4.3
-      '@polkadot/wasm-bridge': 7.4.1(@polkadot/util@13.4.3)(@polkadot/x-randomvalues@13.4.3(@polkadot/util@13.4.3)(@polkadot/wasm-util@7.4.1(@polkadot/util@13.3.1)))
+      '@polkadot/wasm-bridge': 7.4.1(@polkadot/util@13.4.3)(@polkadot/x-randomvalues@13.4.3(@polkadot/util@13.4.3)(@polkadot/wasm-util@7.4.1(@polkadot/util@13.4.3)))
       '@polkadot/wasm-crypto-asmjs': 7.4.1(@polkadot/util@13.4.3)
-      '@polkadot/wasm-crypto-init': 7.4.1(@polkadot/util@13.4.3)(@polkadot/x-randomvalues@13.4.3(@polkadot/util@13.4.3)(@polkadot/wasm-util@7.4.1(@polkadot/util@13.3.1)))
+      '@polkadot/wasm-crypto-init': 7.4.1(@polkadot/util@13.4.3)(@polkadot/x-randomvalues@13.4.3(@polkadot/util@13.4.3)(@polkadot/wasm-util@7.4.1(@polkadot/util@13.4.3)))
       '@polkadot/wasm-crypto-wasm': 7.4.1(@polkadot/util@13.4.3)
       '@polkadot/wasm-util': 7.4.1(@polkadot/util@13.4.3)
-      '@polkadot/x-randomvalues': 13.4.3(@polkadot/util@13.4.3)(@polkadot/wasm-util@7.4.1(@polkadot/util@13.3.1))
+      '@polkadot/x-randomvalues': 13.4.3(@polkadot/util@13.4.3)(@polkadot/wasm-util@7.4.1(@polkadot/util@13.4.3))
       tslib: 2.8.1
 
   '@polkadot/wasm-util@7.4.1(@polkadot/util@13.3.1)':
@@ -2443,10 +2329,10 @@ snapshots:
       '@polkadot/x-global': 13.3.1
       tslib: 2.8.1
 
-  '@polkadot/x-randomvalues@13.4.3(@polkadot/util@13.4.3)(@polkadot/wasm-util@7.4.1(@polkadot/util@13.3.1))':
+  '@polkadot/x-randomvalues@13.4.3(@polkadot/util@13.4.3)(@polkadot/wasm-util@7.4.1(@polkadot/util@13.4.3))':
     dependencies:
       '@polkadot/util': 13.4.3
-      '@polkadot/wasm-util': 7.4.1(@polkadot/util@13.3.1)
+      '@polkadot/wasm-util': 7.4.1(@polkadot/util@13.4.3)
       '@polkadot/x-global': 13.4.3
       tslib: 2.8.1
 
@@ -2585,61 +2471,6 @@ snapshots:
 
   '@substrate/ss58-registry@1.51.0': {}
 
-  '@swc/core-darwin-arm64@1.11.16':
-    optional: true
-
-  '@swc/core-darwin-x64@1.11.16':
-    optional: true
-
-  '@swc/core-linux-arm-gnueabihf@1.11.16':
-    optional: true
-
-  '@swc/core-linux-arm64-gnu@1.11.16':
-    optional: true
-
-  '@swc/core-linux-arm64-musl@1.11.16':
-    optional: true
-
-  '@swc/core-linux-x64-gnu@1.11.16':
-    optional: true
-
-  '@swc/core-linux-x64-musl@1.11.16':
-    optional: true
-
-  '@swc/core-win32-arm64-msvc@1.11.16':
-    optional: true
-
-  '@swc/core-win32-ia32-msvc@1.11.16':
-    optional: true
-
-  '@swc/core-win32-x64-msvc@1.11.16':
-    optional: true
-
-  '@swc/core@1.11.16':
-    dependencies:
-      '@swc/counter': 0.1.3
-      '@swc/types': 0.1.21
-    optionalDependencies:
-      '@swc/core-darwin-arm64': 1.11.16
-      '@swc/core-darwin-x64': 1.11.16
-      '@swc/core-linux-arm-gnueabihf': 1.11.16
-      '@swc/core-linux-arm64-gnu': 1.11.16
-      '@swc/core-linux-arm64-musl': 1.11.16
-      '@swc/core-linux-x64-gnu': 1.11.16
-      '@swc/core-linux-x64-musl': 1.11.16
-      '@swc/core-win32-arm64-msvc': 1.11.16
-      '@swc/core-win32-ia32-msvc': 1.11.16
-      '@swc/core-win32-x64-msvc': 1.11.16
-    optional: true
-
-  '@swc/counter@0.1.3':
-    optional: true
-
-  '@swc/types@0.1.21':
-    dependencies:
-      '@swc/counter': 0.1.3
-    optional: true
-
   '@types/bn.js@5.1.6':
     dependencies:
       '@types/node': 22.13.9
@@ -2656,7 +2487,7 @@ snapshots:
     dependencies:
       undici-types: 6.20.0
 
-  '@vitest/coverage-v8@3.1.4(vitest@3.1.4(@types/node@22.13.9)(jiti@2.4.2)(jsdom@26.0.0)(terser@5.39.0))':
+  '@vitest/coverage-v8@3.1.4(vitest@3.1.4(@types/node@22.13.9)(jsdom@26.0.0))':
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@bcoe/v8-coverage': 1.0.2
@@ -2670,7 +2501,7 @@ snapshots:
       std-env: 3.9.0
       test-exclude: 7.0.1
       tinyrainbow: 2.0.0
-      vitest: 3.1.4(@types/node@22.13.9)(jiti@2.4.2)(jsdom@26.0.0)(terser@5.39.0)
+      vitest: 3.1.4(@types/node@22.13.9)(jsdom@26.0.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -2681,13 +2512,13 @@ snapshots:
       chai: 5.2.0
       tinyrainbow: 2.0.0
 
-  '@vitest/mocker@3.1.4(vite@6.3.5(@types/node@22.13.9)(jiti@2.4.2)(terser@5.39.0))':
+  '@vitest/mocker@3.1.4(vite@6.3.5(@types/node@22.13.9))':
     dependencies:
       '@vitest/spy': 3.1.4
       estree-walker: 3.0.3
       magic-string: 0.30.17
     optionalDependencies:
-      vite: 6.3.5(@types/node@22.13.9)(jiti@2.4.2)(terser@5.39.0)
+      vite: 6.3.5(@types/node@22.13.9)
 
   '@vitest/pretty-format@3.1.4':
     dependencies:
@@ -2718,9 +2549,6 @@ snapshots:
     optionalDependencies:
       typescript: 5.8.2
 
-  acorn@8.14.1:
-    optional: true
-
   agent-base@7.1.3: {}
 
   ansi-regex@5.0.1: {}
@@ -2746,9 +2574,6 @@ snapshots:
   brace-expansion@2.0.1:
     dependencies:
       balanced-match: 1.0.2
-
-  buffer-from@1.1.2:
-    optional: true
 
   bundle-require@5.1.0(esbuild@0.25.0):
     dependencies:
@@ -2785,9 +2610,6 @@ snapshots:
   combined-stream@1.0.8:
     dependencies:
       delayed-stream: 1.0.0
-
-  commander@2.20.3:
-    optional: true
 
   commander@4.1.1: {}
 
@@ -3039,9 +2861,6 @@ snapshots:
     optionalDependencies:
       '@pkgjs/parseargs': 0.11.0
 
-  jiti@2.4.2:
-    optional: true
-
   joycon@3.1.1: {}
 
   jsdom@26.0.0:
@@ -3191,11 +3010,10 @@ snapshots:
 
   pirates@4.0.6: {}
 
-  postcss-load-config@6.0.1(jiti@2.4.2)(postcss@8.5.3):
+  postcss-load-config@6.0.1(postcss@8.5.3):
     dependencies:
       lilconfig: 3.1.3
     optionalDependencies:
-      jiti: 2.4.2
       postcss: 8.5.3
 
   postcss@8.5.3:
@@ -3283,15 +3101,6 @@ snapshots:
 
   source-map-js@1.2.1: {}
 
-  source-map-support@0.5.21:
-    dependencies:
-      buffer-from: 1.1.2
-      source-map: 0.6.1
-    optional: true
-
-  source-map@0.6.1:
-    optional: true
-
   source-map@0.8.0-beta.0:
     dependencies:
       whatwg-url: 7.1.0
@@ -3335,14 +3144,6 @@ snapshots:
       has-flag: 4.0.0
 
   symbol-tree@3.2.4: {}
-
-  terser@5.39.0:
-    dependencies:
-      '@jridgewell/source-map': 0.3.6
-      acorn: 8.14.1
-      commander: 2.20.3
-      source-map-support: 0.5.21
-    optional: true
 
   test-exclude@7.0.1:
     dependencies:
@@ -3408,7 +3209,7 @@ snapshots:
 
   tslib@2.8.1: {}
 
-  tsup@8.4.0(@swc/core@1.11.16)(jiti@2.4.2)(postcss@8.5.3)(typescript@5.8.2):
+  tsup@8.4.0(postcss@8.5.3)(typescript@5.8.2):
     dependencies:
       bundle-require: 5.1.0(esbuild@0.25.0)
       cac: 6.7.14
@@ -3418,7 +3219,7 @@ snapshots:
       esbuild: 0.25.0
       joycon: 3.1.1
       picocolors: 1.1.1
-      postcss-load-config: 6.0.1(jiti@2.4.2)(postcss@8.5.3)
+      postcss-load-config: 6.0.1(postcss@8.5.3)
       resolve-from: 5.0.0
       rollup: 4.40.2
       source-map: 0.8.0-beta.0
@@ -3427,7 +3228,6 @@ snapshots:
       tinyglobby: 0.2.12
       tree-kill: 1.2.2
     optionalDependencies:
-      '@swc/core': 1.11.16
       postcss: 8.5.3
       typescript: 5.8.2
     transitivePeerDependencies:
@@ -3459,13 +3259,13 @@ snapshots:
       - utf-8-validate
       - zod
 
-  vite-node@3.1.4(@types/node@22.13.9)(jiti@2.4.2)(terser@5.39.0):
+  vite-node@3.1.4(@types/node@22.13.9):
     dependencies:
       cac: 6.7.14
       debug: 4.4.0
       es-module-lexer: 1.7.0
       pathe: 2.0.3
-      vite: 6.3.5(@types/node@22.13.9)(jiti@2.4.2)(terser@5.39.0)
+      vite: 6.3.5(@types/node@22.13.9)
     transitivePeerDependencies:
       - '@types/node'
       - jiti
@@ -3480,18 +3280,18 @@ snapshots:
       - tsx
       - yaml
 
-  vite-tsconfig-paths@5.1.4(typescript@5.8.2)(vite@6.3.5(@types/node@22.13.9)(jiti@2.4.2)(terser@5.39.0)):
+  vite-tsconfig-paths@5.1.4(typescript@5.8.2)(vite@6.3.5(@types/node@22.13.9)):
     dependencies:
       debug: 4.4.0
       globrex: 0.1.2
       tsconfck: 3.1.5(typescript@5.8.2)
     optionalDependencies:
-      vite: 6.3.5(@types/node@22.13.9)(jiti@2.4.2)(terser@5.39.0)
+      vite: 6.3.5(@types/node@22.13.9)
     transitivePeerDependencies:
       - supports-color
       - typescript
 
-  vite@6.3.5(@types/node@22.13.9)(jiti@2.4.2)(terser@5.39.0):
+  vite@6.3.5(@types/node@22.13.9):
     dependencies:
       esbuild: 0.25.0
       fdir: 6.4.4(picomatch@4.0.2)
@@ -3502,13 +3302,11 @@ snapshots:
     optionalDependencies:
       '@types/node': 22.13.9
       fsevents: 2.3.3
-      jiti: 2.4.2
-      terser: 5.39.0
 
-  vitest@3.1.4(@types/node@22.13.9)(jiti@2.4.2)(jsdom@26.0.0)(terser@5.39.0):
+  vitest@3.1.4(@types/node@22.13.9)(jsdom@26.0.0):
     dependencies:
       '@vitest/expect': 3.1.4
-      '@vitest/mocker': 3.1.4(vite@6.3.5(@types/node@22.13.9)(jiti@2.4.2)(terser@5.39.0))
+      '@vitest/mocker': 3.1.4(vite@6.3.5(@types/node@22.13.9))
       '@vitest/pretty-format': 3.1.4
       '@vitest/runner': 3.1.4
       '@vitest/snapshot': 3.1.4
@@ -3525,8 +3323,8 @@ snapshots:
       tinyglobby: 0.2.13
       tinypool: 1.0.2
       tinyrainbow: 2.0.0
-      vite: 6.3.5(@types/node@22.13.9)(jiti@2.4.2)(terser@5.39.0)
-      vite-node: 3.1.4(@types/node@22.13.9)(jiti@2.4.2)(terser@5.39.0)
+      vite: 6.3.5(@types/node@22.13.9)
+      vite-node: 3.1.4(@types/node@22.13.9)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 22.13.9

--- a/packages/sdk/src/query-client.ts
+++ b/packages/sdk/src/query-client.ts
@@ -23,7 +23,7 @@ export function createQueryClient(config: { url: string }) {
  * Queries a request by CommitmentHash
  *
  * @example
- * import { createQueryClient, queryRequest } from "hyperbridge-sdk"
+ * import { createQueryClient, queryRequest } from "@hyperbridge/sdk"
  *
  * const queryClient = createQueryClient({
  *   url: "http://localhost:3000", // URL of the Hyperbridge indexer API
@@ -39,7 +39,7 @@ export function queryPostRequest(params: { commitmentHash: string; queryClient: 
  * Queries a GET Request by CommitmentHash
  *
  * @example
- * import { createQueryClient, queryRequest } from "hyperbridge-sdk"
+ * import { createQueryClient, queryRequest } from "@hyperbridge/sdk"
  *
  * const queryClient = createQueryClient({
  *   url: "http://localhost:3000", // URL of the Hyperbridge indexer API
@@ -55,7 +55,7 @@ export function queryGetRequest(params: { commitmentHash: string; queryClient: I
  * Queries an order by CommitmentHash
  *
  * @example
- * import { createQueryClient, queryOrder } from "hyperbridge-sdk"
+ * import { createQueryClient, queryOrder } from "@hyperbridge/sdk"
  *
  * const queryClient = createQueryClient({
  *   url: "http://localhost:3000", // URL of the Hyperbridge indexer API

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,7 +1,7 @@
 lockfileVersion: '9.0'
 
 settings:
-  autoInstallPeers: true
+  autoInstallPeers: false
   excludeLinksFromLockfile: false
 
 importers:


### PR DESCRIPTION
Migrates the main SDK package from an unscoped name (`hyperbridge-sdk`) to a scoped package name (`@hyperbridge/sdk`) under the `@hyperbridge` organization.

### Changes:
- **Package name**: Updated `packages/sdk/package.json` to use `@hyperbridge/sdk`
- **Import statements**: Updated all import statements across the codebase from `"hyperbridge-sdk"` to `"@hyperbridge/sdk"`
- **Workspace dependencies**: Updated workspace references in `packages/filler/package.json` and other dependent packages
- **GitHub workflows**: Updated pnpm filter commands in CI workflows to use the new package name
- **Documentation**: Updated README.md with new installation and usage examples
- **Vite plugin**: Updated plugin references to use the scoped package name
- **Lock files**: Regenerated pnpm lock files to reflect the new package structure