### PR TITLE
fix: set counterparty to match submission destination

### DIFF
--- a/packages/sdk/src/client.ts
+++ b/packages/sdk/src/client.ts
@@ -1583,7 +1583,7 @@ export class IndexerClient {
 		logger.trace("Query Request Proof from sourceChain")
 		const proof = await sourceChain.queryProof(
 			{ Requests: [commitment] },
-			this.config.dest.stateMachineId,
+			this.config.hyperbridge.stateMachineId,
 			latestStateMachineHeight,
 		)
 


### PR DESCRIPTION
- Fixed `aggregateTransactionWithCommitment` method to use the submission destination as the `counterparty` when querying proof from source chain.