### PR TITLE
Fix: GitHub Actions multiline output formatting in changelog generation

### DIFF
--- a/.github/workflows/publish-sdk.yml
+++ b/.github/workflows/publish-sdk.yml
@@ -84,8 +84,8 @@ jobs:
             - name: Create GitHub Release
               uses: softprops/action-gh-release@v1
               with:
-                  tag_name: ${{ steps.get_version.outputs.VERSION }}
-                  name: Release ${{ steps.get_version.outputs.VERSION }}
+                  tag_name: hyperbridge-sdk-${{ steps.get_version.outputs.VERSION }}
+                  name: Hyperbridge SDK ${{ steps.get_version.outputs.VERSION }}
                   body: ${{ steps.changelog.outputs.CHANGELOG }}
                   draft: true
               env:


### PR DESCRIPTION
The changelog generation step was incorrectly formatting multiline output for GitHub Actions, writing each line individually to `$GITHUB_OUTPUT` instead of using proper multiline variable syntax.

**Fix:**
- Use grouping operator `{ ... } >> $GITHUB_OUTPUT` to properly format multiline output variables.
- Ensures the changelog content is correctly captured as a single multiline variable that can be referenced in subsequent steps.

This resolves the `EOF` delimiter issue where GitHub Actions wasn't properly interpreting the multiline variable boundaries.