### PR TITLE
chore: bump sdk version to 1.1.12

### DIFF
--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@hyperbridge/sdk",
-	"version": "1.1.10",
+	"version": "1.1.12",
 	"description": "The hyperclient SDK provides utilities for querying proofs and statuses for cross-chain requests from HyperBridge.",
 	"type": "module",
 	"types": "./dist/node/index.d.ts",


### PR DESCRIPTION
Bumps the version of the Hyperbridge SDK

### Changes
- Updated version in `packages/sdk/package.json` from `1.1.10` → `1.1.12`


_Previous tag `1.1.11` wasn't merged_