### PR TITLE
chore: remove lastUpdatedAt field from Relayer entity

### DIFF
--- a/packages/indexer/src/configs/schema.graphql
+++ b/packages/indexer/src/configs/schema.graphql
@@ -211,10 +211,30 @@ type Relayer @entity {
 	"""
 	perChainStats: [RelayerStatsPerChain]! @derivedFrom(field: "relayer")
 
-	# """
-	# Last updated at
-	# """
-	# lastUpdatedAt: BigInt
+	"""
+	Latest activity for this relayer
+	"""
+	latestActivity: RelayerActivity @derivedFrom(field: "relayer")
+}
+
+"""
+Hyperbridge Relayer Activity
+"""
+type RelayerActivity @entity {
+    """
+    Unique Identifier for the activity
+    """
+    id: ID!
+
+    """
+    Relayer the activities are for
+    """
+    relayer: Relayer!
+
+    """
+	Last updated at
+	"""
+	lastUpdatedAt: BigInt!
 }
 
 """

--- a/packages/indexer/src/services/relayer.service.ts
+++ b/packages/indexer/src/services/relayer.service.ts
@@ -1,5 +1,5 @@
 import { ProtocolParticipant } from "@/configs/src/types/enums"
-import { Relayer, Transfer } from "@/configs/src/types/models"
+import { Relayer, RelayerActivity, Transfer } from "@/configs/src/types/models"
 import { RelayerChainStatsService } from "@/services/relayerChainStats.service"
 // import {
 //  HandlePostRequestsTransaction,
@@ -16,11 +16,7 @@ export class RelayerService {
 		let relayer = await Relayer.get(relayer_id)
 
 		if (typeof relayer === "undefined") {
-			relayer = Relayer.create({
-				id: relayer_id,
-				// lastUpdatedAt: timestamp,
-			})
-
+			relayer = Relayer.create({ id: relayer_id })
 			await relayer.save()
 		}
 
@@ -36,7 +32,7 @@ export class RelayerService {
 		const relayer_chain_stats = await RelayerChainStatsService.findOrCreate(relayer.id, transfer.chain)
 
 		relayer_chain_stats.feesEarned += transfer.amount
-		// relayer.lastUpdatedAt = timestamp
+		await this.updateRelayerActivity(relayer.id, timestamp)
 
 		relayer.save()
 		relayer_chain_stats.save()
@@ -52,10 +48,25 @@ export class RelayerService {
 		const relayer_chain_stats = await RelayerChainStatsService.findOrCreate(relayer.id, chain)
 
 		relayer_chain_stats.numberOfSuccessfulMessagesDelivered += BigInt(1)
-		// relayer.lastUpdatedAt = timestamp
+		await this.updateRelayerActivity(relayer.id, timestamp)
 
 		await relayer.save()
 		await relayer_chain_stats.save()
+	}
+
+	/**
+	 * Update relayer activity
+	 * @param relayerId The relayer address
+	 * @param timestamp The timestamp of the activit
+	 */
+	static async updateRelayerActivity(relayerId: string, timestamp: bigint) {
+		let activity = await RelayerActivity.get(relayerId)
+		if (!activity) {
+			activity = RelayerActivity.create({ id: relayerId, relayerId, lastUpdatedAt: timestamp })
+		}
+
+		activity.lastUpdatedAt = timestamp
+		await activity.save()
 	}
 
 	//  /**


### PR DESCRIPTION
Refactors how relayer activity timestamps are tracked to improve schema flexibility and avoid auto-migration issues.

### Changes:
- **Schema**: 
  - Removed `lastUpdatedAt: BigInt` field from the `Relayer` entity
  - Added new `RelayerActivity` entity to track relayer activity timestamps
  - Added `latestActivity: RelayerActivity` field to `Relayer` using `@derivedFrom(field: "relayer")`

- **Service**: 
  - Added `updateRelayerActivity()` method to manage relayer activity records
  - Updated `updateFeesEarned()` and `updateMessageDelivered()` to call `updateRelayerActivity()` instead of directly setting `lastUpdatedAt`

_Note: The original `lastUpdatedAt` field was introduced at [#82](https://github.com/polytope-labs/hyperbridge-sdk/pull/82) and caused auto-migration issues. This refactor provides the same data through a more robust relationship structure._