### PR TITLE
fix: clear code delegation

### DIFF
--- a/packages/filler/src/strategies/swap.ts
+++ b/packages/filler/src/strategies/swap.ts
@@ -146,6 +146,24 @@ export class StableSwapFiller implements FillerStrategy {
 				authorizationList: [authorization],
 			})
 
+			// Clear delegation after filling the order
+
+			const revertAuthorization = await walletClient.signAuthorization({
+				contractAddress: ADDRESS_ZERO,
+				account: walletClient.account!,
+				executor: "self",
+			})
+
+			const resetAuthTx = await walletClient.sendTransaction({
+				account: walletClient.account!,
+				chain: destClient.chain,
+				to: walletClient.account!.address,
+				data: "0x",
+				authorizationList: [revertAuthorization],
+			})
+
+			console.log("Auth reset tx:", resetAuthTx)
+
 			const endTime = Date.now()
 			const processingTimeMs = endTime - startTime
 


### PR DESCRIPTION
When the filler delegates its EOA to a smart contract (such as BatchExecutor) using EIP-7702, there can be an edge case where the filler address stops supporting native token transfers.

Example:

Filler address: 0x123 (same address on both BSC and Gnosis chains)

Order 1: Source = Gnosis, Destination = BSC, requires swaps on destination with delegation. The order will be successfully filled as expected
Important: EIP-7702 delegation now persists on the BSC chain for address 0x123

Order 2: Source = BSC, Destination = Gnosis, input token = native token. The order will be successfully filled on Gnosis
Problem: During EscrowRefund, the transaction may revert because address 0x123 on BSC still has active delegation to BatchExecutor, preventing it from receiving native tokens

Root Cause: The delegation from Order 1 remains active on the destination chain (BSC), causing the filler address to behave as a smart contract rather than a normal EOA when receiving native token refunds.