### PR TITLE
fix: await entity save ops in indexer

### DIFF
--- a/packages/indexer/src/services/getRequest.service.ts
+++ b/packages/indexer/src/services/getRequest.service.ts
@@ -84,7 +84,7 @@ export class GetRequestService {
 				commitment: id,
 			})
 
-			getRequest.save()
+			await getRequest.save()
 
 			logger.info(
 				`Saved GetRequest Event: ${JSON.stringify({
@@ -108,7 +108,7 @@ export class GetRequestService {
 			if (status !== undefined) getRequest.status = status
 			if (chain !== undefined) getRequest.chain = chain
 
-			getRequest.save()
+			await getRequest.save()
 
 			logger.info(
 				`Updated GetRequest Event: ${JSON.stringify({
@@ -140,7 +140,7 @@ export class GetRequestService {
 			status,
 		})
 
-		getRequest.save()
+		await getRequest.save()
 
 		logger.info(
 			`Created new get request while attempting get request update with details ${JSON.stringify({

--- a/packages/indexer/src/services/relayer.service.ts
+++ b/packages/indexer/src/services/relayer.service.ts
@@ -37,8 +37,8 @@ export class RelayerService {
 		relayer_chain_stats.feesEarned += transfer.amount
 		await this.updateRelayerActivity(relayer.id, timestamp)
 
-		relayer.save()
-		relayer_chain_stats.save()
+		await relayer.save()
+		await relayer_chain_stats.save()
 	}
 
 	/**
@@ -56,8 +56,8 @@ export class RelayerService {
 		relayer_chain_stats.feesEarned += fee
 		await this.updateRelayerActivity(relayer.id, timestamp)
 
-		relayer.save()
-		relayer_chain_stats.save()
+		await relayer.save()
+		await relayer_chain_stats.save()
 	}
 
 	/**
@@ -157,7 +157,6 @@ export class RelayerService {
 	// 			description,
 	// 			timestamp,
 	// 		)
-
 
 	// 		await relayer.save()
 	// 		await relayer_chain_stats.save()


### PR DESCRIPTION
@ddboy19912 Reported that there were two `getRequests` in the db, which was not possible because we are gracefully handling delayed sync conditions for source and hyperbridge in the [getRequestService](https://github.com/polytope-labs/hyperbridge-sdk/blob/531cf5ebd1868e73681c8f3e7735eb3bcdd0f3c0/packages/indexer/src/services/getRequest.service.ts#L94). 

Found out we are not awaiting some save operations. 