### PR TITLE
Only index tokens on mainnet

### DIFF
--- a/packages/indexer/scripts/templates/substrate-chain.yaml.hbs
+++ b/packages/indexer/scripts/templates/substrate-chain.yaml.hbs
@@ -41,16 +41,16 @@ dataSources:
           kind: substrate/BlockHandler
           filter:
             modulo: 3600 # Indexings 1 block every 6 hours (6 seconds per block indexing).
-        - handler: handleTokenIndexing
-          kind: substrate/BlockHandler
-          filter:
-            modulo: 1 # Indexings every block.
 {{/if}}
 {{#if enablePriceIndexing}}
         - handler: handlePriceIndexing
           kind: substrate/BlockHandler
           filter:
             modulo: 10 # Indexings 1 block every minute (6 seconds per block indexing).
+        - handler: handleTokenIndexing
+          kind: substrate/BlockHandler
+          filter:
+            modulo: 1 # Indexings every block.
 {{/if}}
 
 repository: 'https://github.com/polytope-labs/hyperbridge'


### PR DESCRIPTION
Ensures token indexing is only available on mainnet configs